### PR TITLE
fix: redact secrets in -T show-config output (closes #1)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -305,7 +305,15 @@ func Execute(opts ExecuteOptions) error {
 		return err
 	}
 	if opts.ShowConfig != nil && *opts.ShowConfig {
-		fmt.Fprintf(os.Stdout, "%+v", conf)
+		redacted := *conf
+		redacted.CrowdSecConfig.CrowdSecLAPIKey = "[REDACTED]"
+		redactedAccounts := make([]cfg.AccountConfig, len(conf.CloudflareConfig.Accounts))
+		copy(redactedAccounts, conf.CloudflareConfig.Accounts)
+		for i := range redactedAccounts {
+			redactedAccounts[i].Token = "[REDACTED]"
+		}
+		redacted.CloudflareConfig.Accounts = redactedAccounts
+		fmt.Fprintf(os.Stdout, "%+v", &redacted)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

The `-T` flag printed the full `BouncerConfig` struct to stdout via `fmt.Fprintf(os.Stdout, "%+v", conf)`, exposing `CrowdSecLAPIKey` and Cloudflare account tokens in plaintext. In containerised deployments stdout is shipped to log aggregation where secrets persist indefinitely.

## Changes

- Create a shallow copy of the config before printing
- Replace `CrowdSecConfig.CrowdSecLAPIKey` with `[REDACTED]`
- Replace each `CloudflareConfig.Accounts[*].Token` with `[REDACTED]`
- Print the redacted copy instead of the original

## Test plan

- Run `bouncer -T -c config.yaml` and verify LAPI key and CF tokens show `[REDACTED]`
- Verify all other config fields still display correctly

Closes #1

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
