### PR TITLE
fix: store turnstile secret as Workers Secret, redact trace logs (closes #2)

### DIFF
--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -594,11 +594,16 @@ func (m *CloudflareAccountManager) ProcessDeletedDecisions(decisions []*models.D
 
 type WidgetTokenCfg struct {
 	SiteKey string `json:"site_key"`
-	Secret  string `json:"secret"`
+	Secret  string `json:"-"` // Never stored in KV; written to Workers Secrets
 }
 
 func (m *CloudflareAccountManager) writeWidgetCfgToKV(ctx context.Context, widgetTokenCfgByDomain map[string]WidgetTokenCfg) error {
-	turnstileConfig, err := json.Marshal(widgetTokenCfgByDomain)
+	// Write site keys (public) to KV — secrets are stored separately via Workers Secrets
+	kvData := make(map[string]map[string]string, len(widgetTokenCfgByDomain))
+	for domain, cfg := range widgetTokenCfgByDomain {
+		kvData[domain] = map[string]string{"site_key": cfg.SiteKey}
+	}
+	turnstileConfig, err := json.Marshal(kvData)
 	if err != nil {
 		return err
 	}
@@ -607,15 +612,41 @@ func (m *CloudflareAccountManager) writeWidgetCfgToKV(ctx context.Context, widge
 		Value: string(turnstileConfig),
 	}
 	m.logger.Infof("Writing turnstile cfg")
-	resp, err := m.api.WriteWorkersKVEntries(ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.WriteWorkersKVEntriesParams{
+	_, err = m.api.WriteWorkersKVEntries(ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.WriteWorkersKVEntriesParams{
 		NamespaceID: m.NamespaceID,
 		KVs:         []*cf.WorkersKVPair{&kv},
 	})
 	if err != nil {
 		return err
 	}
-	m.logger.Tracef("resp after writing turnstile cfg %+v", resp)
+
+	// Store each domain's secret as an encrypted Workers Secret
+	for domain, cfg := range widgetTokenCfgByDomain {
+		secretName := turnstileSecretName(domain)
+		_, err := m.api.SetWorkersSecret(ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.SetWorkersSecretParams{
+			ScriptName: m.Worker.ScriptName,
+			Secret: &cf.WorkersPutSecretRequest{
+				Name: secretName,
+				Text: cfg.Secret,
+				Type: "secret_text",
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to set turnstile secret for %s: %w", domain, err)
+		}
+		m.logger.Debugf("Turnstile secret stored as Workers Secret: %s", secretName)
+	}
+
+	m.logger.Tracef("Turnstile config written to KV")
 	return nil
+}
+
+// turnstileSecretName returns the Workers Secret env var name for a domain's turnstile secret.
+// The Worker JS reads this as env.TURNSTILE_SECRET_<normalized_domain>.
+func turnstileSecretName(domain string) string {
+	normalized := strings.ReplaceAll(domain, ".", "_")
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+	return "TURNSTILE_SECRET_" + strings.ToUpper(normalized)
 }
 
 func (m *CloudflareAccountManager) ProcessNewDecisions(decisions []*models.Decision) error {
@@ -756,7 +787,7 @@ func (m *CloudflareAccountManager) CreateTurnstileWidgets() (map[string]WidgetTo
 			if err != nil {
 				return err
 			}
-			zoneLogger.Tracef("resp: %+v", resp)
+			zoneLogger.Tracef("Widget created: siteKey=%s", resp.SiteKey)
 			zoneLogger.Info(("Done creating turnstile widget"))
 			widgetTokenCfgByDomainLock.Lock()
 			defer widgetTokenCfgByDomainLock.Unlock()
@@ -819,7 +850,7 @@ func (m *CloudflareAccountManager) HandleTurnstile() error {
 						SiteKey:               widgetTokenCfg.SiteKey,
 						InvalidateImmediately: true,
 					})
-					zoneLogger.Tracef("resp: %+v", resp)
+					zoneLogger.Tracef("Widget rotated: siteKey=%s", widgetTokenCfg.SiteKey)
 					if err != nil {
 						return err
 					}

--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7059,6 +7059,11 @@ const ipaddr = __webpack_require__(640);
 
 
 
+const getTurnstileSecret = (env, domain) => {
+  const normalized = domain.replace(/[.\-]/g, '_').toUpperCase();
+  return env[`TURNSTILE_SECRET_${normalized}`] || null;
+}
+
 const getZoneFromReqURL = (reqURL, actionsByDomain) => {
   // loop through
   for (const [domain] of Object.entries(actionsByDomain)) {
@@ -7172,12 +7177,18 @@ const writeToKV = async (kv, key, value) => {
       }
       turnstileCfg = turnstileCfg[zoneForThisRequest]
 
+      const turnstile_secret = getTurnstileSecret(env, zoneForThisRequest);
+      if (!turnstile_secret) {
+        console.log("No turnstile secret found for zone")
+        return fetch(request)
+      }
+
       const cookie = (0,dist/* parse */.qg)(request.headers.get("Cookie") || "");
       if (cookie[`${zoneForThisRequest}_captcha`] !== undefined) {
         console.log("captchaAuth cookie is present")
         // Check if the JWT token is valid
         try {
-          const decoded = await index_default.verify(cookie[`${zoneForThisRequest}_captcha`], turnstileCfg["secret"] + ip, {throwError: true});
+          const decoded = await index_default.verify(cookie[`${zoneForThisRequest}_captcha`], turnstile_secret + ip, {throwError: true});
           return fetch(request)
         } catch (err) {
           console.log(err)
@@ -7188,7 +7199,7 @@ const writeToKV = async (kv, key, value) => {
         const formBody = await request.clone().formData();
         if (formBody.get('cf-turnstile-response')) {
           console.log("Handling turnstile post")
-          return await handleTurnstilePost(request, formBody, turnstileCfg["secret"], zoneForThisRequest)
+          return await handleTurnstilePost(request, formBody, turnstile_secret, zoneForThisRequest)
         }
       }
 

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -3,6 +3,11 @@ import jwt from '@tsndr/cloudflare-worker-jwt'
 import { parse } from "cookie";
 
 
+const getTurnstileSecret = (env, domain) => {
+  const normalized = domain.replace(/[.\-]/g, '_').toUpperCase();
+  return env[`TURNSTILE_SECRET_${normalized}`] || null;
+}
+
 const getZoneFromReqURL = (reqURL, actionsByDomain) => {
   // loop through
   for (const [domain] of Object.entries(actionsByDomain)) {
@@ -116,12 +121,18 @@ export default {
       }
       turnstileCfg = turnstileCfg[zoneForThisRequest]
 
+      const turnstile_secret = getTurnstileSecret(env, zoneForThisRequest);
+      if (!turnstile_secret) {
+        console.log("No turnstile secret found for zone")
+        return fetch(request)
+      }
+
       const cookie = parse(request.headers.get("Cookie") || "");
       if (cookie[`${zoneForThisRequest}_captcha`] !== undefined) {
         console.log("captchaAuth cookie is present")
         // Check if the JWT token is valid
         try {
-          const decoded = await jwt.verify(cookie[`${zoneForThisRequest}_captcha`], turnstileCfg["secret"] + ip, {throwError: true});
+          const decoded = await jwt.verify(cookie[`${zoneForThisRequest}_captcha`], turnstile_secret + ip, {throwError: true});
           return fetch(request)
         } catch (err) {
           console.log(err)
@@ -132,7 +143,7 @@ export default {
         const formBody = await request.clone().formData();
         if (formBody.get('cf-turnstile-response')) {
           console.log("Handling turnstile post")
-          return await handleTurnstilePost(request, formBody, turnstileCfg["secret"], zoneForThisRequest)
+          return await handleTurnstilePost(request, formBody, turnstile_secret, zoneForThisRequest)
         }
       }
 


### PR DESCRIPTION
## Summary

The Turnstile widget secret was stored as plaintext JSON in KV under `TURNSTILE_CONFIG` and leaked via `Tracef` calls after widget creation and rotation. Any Worker on the same account could read the secret from KV and forge valid JWT captcha bypass cookies.

## Changes

- Add `json:"-"` tag to `WidgetTokenCfg.Secret` so it's never serialized to KV
- Store only `site_key` (public) in KV; store secrets via `SetWorkersSecret` (encrypted at rest, not retrievable via API)
- Worker JS reads secret from env binding `TURNSTILE_SECRET_<DOMAIN>` instead of KV
- Replace `Tracef("resp: %+v", resp)` with targeted field logging at all 3 locations (lines 759, 822, 617)
- Add `turnstileSecretName()` helper for consistent domain-to-env-var normalization between Go and JS

## Test plan

- Deploy with captcha-enabled zone, verify Turnstile challenge works end-to-end
- Verify `TURNSTILE_CONFIG` KV entry no longer contains `secret` field
- Verify Workers Secrets list shows `TURNSTILE_SECRET_<DOMAIN>` entries
- Enable trace logging, verify no secrets appear in output
- Verify JWT verification still works (secret read from env, not KV)

Closes #2

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
