### PR TITLE
fix: protect metrics maps with mutex against concurrent access (closes #3)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,9 @@ func (m *metricsHandler) metricsUpdater(met *models.RemediationComponentsMetrics
 		Items: make([]*models.MetricsDetailItem, 0),
 	})
 
+	metrics.MetricsMu.Lock()
+	defer metrics.MetricsMu.Unlock()
+
 	for _, metricFamily := range promMetrics {
 		for _, metric := range metricFamily.GetMetric() {
 			switch metricFamily.GetName() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,6 +1,10 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	BlockedRequestMetricName   = "crowdsec_cloudflare_worker_bouncer_blocked_requests"
@@ -23,6 +27,10 @@ var TotalKeysByAccount = prometheus.NewGaugeVec(
 	},
 	[]string{"account"},
 )
+
+// MetricsMu protects LastBlockedRequestValue and LastProcessedRequestValue
+// from concurrent read/write between metricsUpdater and computeMetricsHandler goroutines.
+var MetricsMu sync.Mutex
 
 var TotalBlockedRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: BlockedRequestMetricName,


### PR DESCRIPTION
## Summary

`LastBlockedRequestValue` and `LastProcessedRequestValue` are package-level maps read/written concurrently by `metricsUpdater` (ticker goroutine) and `computeMetricsHandler` (HTTP handler goroutine on every Prometheus scrape) without any synchronisation. This is a confirmed data race that causes panics (`concurrent map read and map write`) under concurrent scrapes with active traffic.

## Changes

- Add `MetricsMu sync.Mutex` to `pkg/metrics/metrics.go`
- Lock the mutex around the entire map-access loop in `metricsUpdater` (read-modify-write cycle)

## Test plan

- Run `go test -race ./...` and verify no data race detected
- Verify Prometheus metrics still report correctly with concurrent scraping

Closes #3

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
