### PR TITLE
fix: correct boolean logic so -s/-d/-S skip LAPI init (closes #4)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -325,13 +325,19 @@ func Execute(opts ExecuteOptions) error {
 		CAPath:   conf.CrowdSecConfig.CAPath,
 	}
 
-	if (opts.TestConfig != nil && *opts.TestConfig) || (opts.SetupOnly == nil || !*opts.SetupOnly) || (opts.DeleteOnly == nil || !*opts.DeleteOnly) {
+	isSetupOnly := opts.SetupOnly != nil && *opts.SetupOnly
+	isDeleteOnly := opts.DeleteOnly != nil && *opts.DeleteOnly
+	isSetupAutonomous := opts.SetupAutonomous != nil && *opts.SetupAutonomous
+	isTestConfig := opts.TestConfig != nil && *opts.TestConfig
+
+	needsLAPI := isTestConfig || (!isSetupOnly && !isDeleteOnly && !isSetupAutonomous)
+	if needsLAPI {
 		if err := csLAPI.Init(); err != nil {
 			return fmt.Errorf("unable to initialize crowdsec bouncer: %w", err)
 		}
 	}
 
-	if opts.TestConfig != nil && *opts.TestConfig {
+	if isTestConfig {
 		log.Info("config is valid")
 		return nil
 	}
@@ -343,17 +349,15 @@ func Execute(opts ExecuteOptions) error {
 		return err
 	}
 
-	isDeleteOnly := opts.DeleteOnly != nil && *opts.DeleteOnly
-	isSetupAutonomous := opts.SetupAutonomous != nil && *opts.SetupAutonomous
 	deployInfraForManagers(g, cfManagers, isDeleteOnly, isSetupAutonomous, conf.CrowdSecConfig, conf.CloudflareConfig.DecisionsSyncWorker.Cron)
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	if opts.DeleteOnly != nil && *opts.DeleteOnly {
+	if isDeleteOnly {
 		return nil
 	}
 	log.Info("Successfully deployed infra for all accounts")
-	if (opts.SetupOnly != nil && *opts.SetupOnly) || (opts.SetupAutonomous != nil && *opts.SetupAutonomous) {
+	if isSetupOnly || isSetupAutonomous {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

The condition guarding `csLAPI.Init()` used OR between negated `*bool` checks, making it always true. LAPI was initialised even for setup-only (`-s`), delete-only (`-d`), and autonomous (`-S`) modes where LAPI may not be running, causing connection failures that block infrastructure bootstrap and teardown.

## Changes

- Extract flag booleans (`isSetupOnly`, `isDeleteOnly`, `isSetupAutonomous`, `isTestConfig`) once
- Compute `needsLAPI` correctly: only when testing config OR running the full decision loop
- Reuse extracted booleans for later checks, eliminating duplicate nil-guard patterns

## Test plan

- `bouncer -s -c config.yaml` succeeds without LAPI running
- `bouncer -d -c config.yaml` succeeds without LAPI running
- `bouncer -S -c config.yaml` succeeds without LAPI running
- `bouncer -t -c config.yaml` still validates LAPI connectivity
- Normal mode still initialises LAPI as before

Closes #4

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
