### PR TITLE
fix: remove turnstile config write-back that corrupts KV (closes #5)

### DIFF
--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7161,9 +7161,7 @@ const writeToKV = async (kv, key, value) => {
         return fetch(request)
       }
       if (typeof turnstileCfg === "string") {
-        console.log("Converting turnstile config to JSON")
         turnstileCfg = JSON.parse(turnstileCfg)
-        writeToKV(env.CROWDSECCFBOUNCERNS, "TURNSTILE_CONFIG", turnstileCfg)
       }
 
       if (!turnstileCfg[zoneForThisRequest]) {

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -105,9 +105,7 @@ export default {
         return fetch(request)
       }
       if (typeof turnstileCfg === "string") {
-        console.log("Converting turnstile config to JSON")
         turnstileCfg = JSON.parse(turnstileCfg)
-        writeToKV(env.CROWDSECCFBOUNCERNS, "TURNSTILE_CONFIG", turnstileCfg)
       }
 
       if (!turnstileCfg[zoneForThisRequest]) {


### PR DESCRIPTION
## Summary

On the first captcha request, `writeToKV` stored the parsed JavaScript object instead of a `JSON.stringify`'d string. Cloudflare KV coerced it to `"[object Object]"`. All subsequent `JSON.parse("[object Object]")` calls throw, the catch returns `null`, and the worker falls through to `fetch(request)` — permanently bypassing captcha for all banned IPs.

## Changes

- Remove the unnecessary `writeToKV` call in the string-to-object conversion block
- The parsed config is only needed in-memory for the current request; no re-storage needed

## Test plan

- Deploy with captcha-enabled zone
- Trigger captcha for a banned IP — verify challenge page appears
- Trigger again — verify challenge still works (not corrupted)
- Check KV value of `TURNSTILE_CONFIG` — verify it remains valid JSON

Closes #5

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
