### PR TITLE
fix: move KV write outside mutex in turnstile rotator (closes #6)

### DIFF
--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -826,10 +826,14 @@ func (m *CloudflareAccountManager) HandleTurnstile() error {
 					widgetTokenCfg.Secret = resp.Secret
 					widgetTokenCfgByDomainLock.Lock()
 					widgetTokenCfgByDomain[zone.Domain] = widgetTokenCfg
-					if err := m.writeWidgetCfgToKV(ctx, widgetTokenCfgByDomain); err != nil {
-						return err
+					snapshot := make(map[string]WidgetTokenCfg, len(widgetTokenCfgByDomain))
+					for k, v := range widgetTokenCfgByDomain {
+						snapshot[k] = v
 					}
 					widgetTokenCfgByDomainLock.Unlock()
+					if err := m.writeWidgetCfgToKV(ctx, snapshot); err != nil {
+						return err
+					}
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

`writeWidgetCfgToKV` (a full Cloudflare API HTTP round-trip) was called while holding `widgetTokenCfgByDomainLock`. All zone rotator goroutines serialized on this mutex for the full network latency of every rotation, causing head-of-line blocking across all zones.

## Changes

- Snapshot the map under the lock, release it immediately
- Make the network call (`writeWidgetCfgToKV`) on the snapshot outside the lock

## Test plan

- Deploy with multiple captcha-enabled zones
- Trigger simultaneous secret rotations
- Verify rotations complete independently without serializing

Closes #6

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
