### PR TITLE
fix: call markAsWarmed on 204 path to prevent perpetual full-sync (closes #8)

### DIFF
--- a/pkg/cloudflare/decisions-sync-worker/dist/main.js
+++ b/pkg/cloudflare/decisions-sync-worker/dist/main.js
@@ -6454,7 +6454,7 @@ async function resetAllDecisions(accountId, namespaceId, apiToken, kvNamespace) 
 					env.CF_API_TOKEN,
 					env.CROWDSECCFBOUNCERNS
 				);
-                // No need to handle WARMED_UP flag as there is no decisions at all
+				await markAsWarmed(env.CROWDSECCFBOUNCERNS);
 				const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
 				logger.info('KV cleared successfully (LAPI has no decisions)', {
 					totalDuration: `${finalDuration}s`,

--- a/pkg/cloudflare/decisions-sync-worker/src/index.js
+++ b/pkg/cloudflare/decisions-sync-worker/src/index.js
@@ -109,7 +109,7 @@ export default {
 					env.CF_API_TOKEN,
 					env.CROWDSECCFBOUNCERNS
 				);
-                // No need to handle WARMED_UP flag as there is no decisions at all
+				await markAsWarmed(env.CROWDSECCFBOUNCERNS);
 				const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
 				logger.info('KV cleared successfully (LAPI has no decisions)', {
 					totalDuration: `${finalDuration}s`,


### PR DESCRIPTION
## Summary

When LAPI returns HTTP 204 (no decisions), the autonomous sync worker cleared KV and returned early without calling `markAsWarmed`. Every subsequent cron tick treated itself as a first fetch (`startup=true`), issuing full LAPI requests and full KV wipes indefinitely. This affects every fresh CrowdSec deployment.

## Changes

- Add `await markAsWarmed(env.CROWDSECCFBOUNCERNS)` before the early return in the 204 path

## Test plan

- Deploy with empty CrowdSec LAPI (no decisions)
- First cron tick: verify full sync + KV clear + `WARMED_UP` key set
- Second cron tick: verify incremental mode (`startup=false`), no full sync

Closes #8

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
