### PR TITLE
fix: mark warmed after LAPI fetch, not after KV writes (closes #9)

### DIFF
--- a/pkg/cloudflare/decisions-sync-worker/dist/main.js
+++ b/pkg/cloudflare/decisions-sync-worker/dist/main.js
@@ -6437,6 +6437,13 @@ async function resetAllDecisions(accountId, namespaceId, apiToken, kvNamespace) 
 				origins,
 			});
 
+			// Mark warmed immediately after successful LAPI fetch, before KV writes.
+			// This prevents perpetual full-sync storms if KV writes fail on large blocklists.
+			if (isFirst) {
+				await markAsWarmed(env.CROWDSECCFBOUNCERNS);
+				logger.info('Cache marked as warmed after successful LAPI fetch');
+			}
+
 			// Log summary
 			const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 			logger.info('Decision stream completed successfully', {
@@ -6531,12 +6538,6 @@ async function resetAllDecisions(accountId, namespaceId, apiToken, kvNamespace) 
 				logger.info('IP_RANGES changed, updating KV...');
 				await writeIpRanges(env.CROWDSECCFBOUNCERNS, finalRanges);
 			}
-
-            // Step 9: Mark cache as warmed after first successful fetch
-            if (isFirst) {
-                await markAsWarmed(env.CROWDSECCFBOUNCERNS);
-                logger.info('Cache marked as warmed after first fetch');
-            }
 
 			// Final summary
 			const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);

--- a/pkg/cloudflare/decisions-sync-worker/src/index.js
+++ b/pkg/cloudflare/decisions-sync-worker/src/index.js
@@ -92,6 +92,13 @@ export default {
 				origins,
 			});
 
+			// Mark warmed immediately after successful LAPI fetch, before KV writes.
+			// This prevents perpetual full-sync storms if KV writes fail on large blocklists.
+			if (isFirst) {
+				await markAsWarmed(env.CROWDSECCFBOUNCERNS);
+				logger.info('Cache marked as warmed after successful LAPI fetch');
+			}
+
 			// Log summary
 			const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 			logger.info('Decision stream completed successfully', {
@@ -186,12 +193,6 @@ export default {
 				logger.info('IP_RANGES changed, updating KV...');
 				await writeIpRanges(env.CROWDSECCFBOUNCERNS, finalRanges);
 			}
-
-            // Step 9: Mark cache as warmed after first successful fetch
-            if (isFirst) {
-                await markAsWarmed(env.CROWDSECCFBOUNCERNS);
-                logger.info('Cache marked as warmed after first fetch');
-            }
 
 			// Final summary
 			const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);


### PR DESCRIPTION
## Summary

`markAsWarmed` was only called after all KV writes succeeded (step 9). Any exception in steps 1-8 skipped it, causing every subsequent cron tick to re-fetch the full decision set with `startup=true`. For large blocklists (100k+ IPs), this cascades into KV write rate limit failures on every tick — a permanent storm.

## Changes

- Move `markAsWarmed` to immediately after a successful LAPI fetch response, before KV writes begin
- Remove the old step 9 `markAsWarmed` call
- Warm-up now means "LAPI connectivity confirmed", not "all writes completed"

Note: This is complementary to #8 which handles the 204-specific case. This PR handles the general case where any KV write step fails.

## Test plan

- Deploy with large blocklist, simulate KV write failure (e.g., rate limit)
- First cron: full sync, LAPI fetch succeeds, `WARMED_UP` key set
- Second cron: incremental mode despite prior KV write failures
- Verify decisions eventually sync correctly on subsequent ticks

Closes #9

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
