### PR TITLE
fix: use secret as JWT signing key, verify IP as claim (closes #10)

### DIFF
--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7103,8 +7103,9 @@ const handleTurnstilePost = async (request, body, turnstile_secret, zoneForThisR
     console.log('Valid captcha solution;', "Issuing JWT token");
     const jwtToken = await index_default.sign({
       data: "captcha solved",
+      ip: ip,
       exp: Math.floor(Date.now() / 1000) + (2 * (60 * 60))
-    }, turnstile_secret + ip);
+    }, turnstile_secret);
     const newResponse = new Response(null, {
       status: 302
     })
@@ -7177,8 +7178,11 @@ const writeToKV = async (kv, key, value) => {
         console.log("captchaAuth cookie is present")
         // Check if the JWT token is valid
         try {
-          const decoded = await index_default.verify(cookie[`${zoneForThisRequest}_captcha`], turnstileCfg["secret"] + ip, {throwError: true});
-          return fetch(request)
+          const decoded = await index_default.verify(cookie[`${zoneForThisRequest}_captcha`], turnstileCfg["secret"], {throwError: true});
+          if (decoded.payload && decoded.payload.ip === ip) {
+            return fetch(request)
+          }
+          console.log("jwt ip mismatch")
         } catch (err) {
           console.log(err)
         }

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -47,8 +47,9 @@ const handleTurnstilePost = async (request, body, turnstile_secret, zoneForThisR
     console.log('Valid captcha solution;', "Issuing JWT token");
     const jwtToken = await jwt.sign({
       data: "captcha solved",
+      ip: ip,
       exp: Math.floor(Date.now() / 1000) + (2 * (60 * 60))
-    }, turnstile_secret + ip);
+    }, turnstile_secret);
     const newResponse = new Response(null, {
       status: 302
     })
@@ -121,8 +122,11 @@ export default {
         console.log("captchaAuth cookie is present")
         // Check if the JWT token is valid
         try {
-          const decoded = await jwt.verify(cookie[`${zoneForThisRequest}_captcha`], turnstileCfg["secret"] + ip, {throwError: true});
-          return fetch(request)
+          const decoded = await jwt.verify(cookie[`${zoneForThisRequest}_captcha`], turnstileCfg["secret"], {throwError: true});
+          if (decoded.payload && decoded.payload.ip === ip) {
+            return fetch(request)
+          }
+          console.log("jwt ip mismatch")
         } catch (err) {
           console.log(err)
         }


### PR DESCRIPTION
## Summary

JWT signing key was constructed as `turnstile_secret + ip` (string concatenation), which is cryptographically broken — `secret="abc" + ip="1.2.3.4"` produces the same key as `secret="ab" + ip="c1.2.3.4"`. Additionally, tokens had no IP binding as a verified claim.

## Changes

- **Sign**: Use `turnstile_secret` alone as the signing key; embed `ip` as a claim in the JWT payload
- **Verify**: After signature verification, check `decoded.payload.ip === CF-Connecting-IP`; reject on mismatch

Note: JTI/replay protection is not included in this minimal fix. Tokens are still replayable within their 2-hour window from the same IP.

## Test plan

- Solve captcha from IP A — verify JWT cookie issued, subsequent requests pass through
- Copy cookie to request from IP B — verify JWT rejected (ip mismatch)
- Verify existing captcha flows still work end-to-end

Closes #10

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
