### PR TITLE
fix: validate decision type before writing to KV (closes #11)

### DIFF
--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -627,7 +627,13 @@ func (m *CloudflareAccountManager) ProcessNewDecisions(decisions []*models.Decis
 		newKVPairByValue[kvPair.Key] = kvPair
 	}
 
+	validDecisionTypes := map[string]bool{"ban": true, "captcha": true}
+
 	for _, decision := range decisions {
+		if !validDecisionTypes[*decision.Type] {
+			m.logger.Warnf("Ignoring decision with unknown type %q for %s", *decision.Type, *decision.Value)
+			continue
+		}
 		origin := *decision.Origin
 		if origin == "lists" {
 			origin = fmt.Sprintf("%s:%s", *decision.Origin, *decision.Scenario)

--- a/pkg/cloudflare/decisions-sync-worker/dist/main.js
+++ b/pkg/cloudflare/decisions-sync-worker/dist/main.js
@@ -5874,6 +5874,9 @@ async function fetchDecisionsStream(lapiUrl, apiKey, options = {}) {
 // String-based scopes (stored as individual KV entries)
 const STRING_SCOPES = ['ip', 'as', 'country'];
 
+// Valid decision types - unknown types are ignored for defence-in-depth
+const VALID_TYPES = ['ban', 'captcha'];
+
 /**
  * Helper function to process string-based decisions (IP, AS, Country)
  * @param {import('../types.js').Decision} decision - Decision object
@@ -5907,6 +5910,10 @@ function processNewDecisions(decisions, existingStringDecisions, existingRanges)
 	const jsonEntries = {}; // Aggregated JSON entries: Ranges
 
 	for (const decision of decisions) {
+		if (!VALID_TYPES.includes(decision.type)) {
+			logger.warn('Ignoring new decision with unknown type', { type: decision.type, value: decision.value });
+			continue;
+		}
 		if (STRING_SCOPES.includes(decision.scope)) {
 			// Handle string-based decisions (IP, AS, Country) - stored as individual KV entries
 			processStringDecision(decision, existingStringDecisions, stringEntries, decision.scope);

--- a/pkg/cloudflare/decisions-sync-worker/src/core/decision-processor.js
+++ b/pkg/cloudflare/decisions-sync-worker/src/core/decision-processor.js
@@ -8,6 +8,9 @@ import logger from '../utils/logger.js';
 // String-based scopes (stored as individual KV entries)
 const STRING_SCOPES = ['ip', 'as', 'country'];
 
+// Valid decision types - unknown types are ignored for defence-in-depth
+const VALID_TYPES = ['ban', 'captcha'];
+
 /**
  * Helper function to process string-based decisions (IP, AS, Country)
  * @param {import('../types.js').Decision} decision - Decision object
@@ -41,6 +44,10 @@ export function processNewDecisions(decisions, existingStringDecisions, existing
 	const jsonEntries = {}; // Aggregated JSON entries: Ranges
 
 	for (const decision of decisions) {
+		if (!VALID_TYPES.includes(decision.type)) {
+			logger.warn('Ignoring new decision with unknown type', { type: decision.type, value: decision.value });
+			continue;
+		}
 		if (STRING_SCOPES.includes(decision.scope)) {
 			// Handle string-based decisions (IP, AS, Country) - stored as individual KV entries
 			processStringDecision(decision, existingStringDecisions, stringEntries, decision.scope);


### PR DESCRIPTION
## Summary

Decision types from LAPI were written to KV without validation. The edge worker's switch only handles `"ban"` and `"captcha"` — any unknown type falls through to `return fetch(request)`, effectively whitelisting the IP. A compromised LAPI could inject `type: "allow"` to bypass enforcement.

## Changes

- **Go** (`pkg/cloudflare/cloudflare.go`): Add `validDecisionTypes` map check in `ProcessNewDecisions`, skip unknown types with warning log
- **JS** (`decisions-sync-worker/src/core/decision-processor.js`): Add `VALID_TYPES` array check in `processNewDecisions`, skip unknown types with warning log

## Test plan

- Inject a decision with `type: "unknown"` via LAPI — verify it's logged as warning and not written to KV
- Verify normal `ban` and `captcha` decisions still work
- Check edge worker behavior is unchanged for valid types

Closes #11

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
