### PR TITLE
fix: replace log.Fatal with log.Errorf in cleanUp (closes #12)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -162,7 +162,7 @@ func cleanUp(managers []*cf.CloudflareAccountManager, c context.CancelFunc, ctx 
 		})
 	}
 	if err := g.Wait(); err != nil {
-		log.Fatal(err)
+		log.Errorf("cleanup failed: %s", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`cleanUp` calls `log.Fatal(err)` when any account cleanup fails. `log.Fatal` calls `os.Exit(1)`, bypassing all remaining defers in the call stack above `cleanUp` and preventing graceful shutdown logging.

## Changes

- Replace `log.Fatal(err)` with `log.Errorf("cleanup failed: %s", err)`

## Test plan

- Simulate cleanup failure for one account — verify error is logged and process exits gracefully
- Verify remaining defers in the call stack execute normally

Closes #12

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
