### PR TITLE
fix: use hostname matching instead of URL substring for zone lookup (closes #13)

### DIFF
--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7060,13 +7060,14 @@ const ipaddr = __webpack_require__(640);
 
 
 const getZoneFromReqURL = (reqURL, actionsByDomain) => {
-  // loop through
-  for (const [domain] of Object.entries(actionsByDomain)) {
-    // if the request URL contains the domain, return the actions
-    if (reqURL.includes(domain)) {
-      return domain
+  try {
+    const hostname = new URL(reqURL).hostname;
+    for (const [domain] of Object.entries(actionsByDomain)) {
+      if (hostname === domain || hostname.endsWith('.' + domain)) {
+        return domain
+      }
     }
-  }
+  } catch (e) { /* invalid URL */ }
 }
 
 const getSupportedActionForZone = (action, actionsForDomain) => {

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -4,13 +4,14 @@ import { parse } from "cookie";
 
 
 const getZoneFromReqURL = (reqURL, actionsByDomain) => {
-  // loop through
-  for (const [domain] of Object.entries(actionsByDomain)) {
-    // if the request URL contains the domain, return the actions
-    if (reqURL.includes(domain)) {
-      return domain
+  try {
+    const hostname = new URL(reqURL).hostname;
+    for (const [domain] of Object.entries(actionsByDomain)) {
+      if (hostname === domain || hostname.endsWith('.' + domain)) {
+        return domain
+      }
     }
-  }
+  } catch (e) { /* invalid URL */ }
 }
 
 const getSupportedActionForZone = (action, actionsForDomain) => {


### PR DESCRIPTION
## Summary

`getZoneFromReqURL` used `String.includes()` against the full URL string, causing wrong zone selection in multi-zone deployments (e.g., `api.example.com` matching `example.com` first) and matching domains appearing in query parameters or path segments.

## Changes

- Parse URL hostname with `new URL(reqURL).hostname`
- Match with exact equality or `.endsWith('.' + domain)` for subdomain support
- Wrap in try/catch for invalid URLs

## Test plan

- Multi-zone deployment: request to `api.example.com` should match `api.example.com` zone, not `example.com`
- Request with domain in query param should not match wrong zone
- Invalid URLs should not throw

Closes #13

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
