### PR TITLE
fix: always attempt D1 cleanup during teardown (closes #14)

### DIFF
--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -462,16 +462,13 @@ func (m *CloudflareAccountManager) cleanupKVNamespaces() error {
 }
 
 func (m *CloudflareAccountManager) cleanupD1Databases(start bool) error {
-	if !m.hasD1Access && !start {
-		return nil
-	}
-
 	m.logger.Debugf("Listing D1 DBs")
 	dbs, _, err := m.api.ListD1Databases(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.ListD1DatabasesParams{})
 
 	if err != nil {
 		if !start {
-			return fmt.Errorf("error while listing D1 DBs, make sure your token has the proper permissions: %w", err)
+			m.logger.Warnf("Unable to list D1 DBs during cleanup (token may lack D1 permissions): %s", err)
+			return nil
 		}
 		dbs = []cf.D1Database{}
 	}


### PR DESCRIPTION
## Summary

`cleanupD1Databases` returned early when `hasD1Access == false` during teardown, skipping cleanup for D1 databases that exist from prior partial deployments. This caused orphaned databases to accumulate toward the per-account Cloudflare D1 limit.

## Changes

- Remove the `hasD1Access` early-return gate during teardown
- Always attempt to list and delete matching D1 databases by name
- If listing fails (token lacks D1 permissions), log warning and return nil instead of hard error

Closes #14

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
