### PR TITLE
fix: wrap D1 metrics write in try/catch (closes #15)

### DIFF
--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7306,17 +7306,21 @@ const writeToKV = async (kv, key, value) => {
 
     const incrementMetrics = async (metricName, ipType, origin, remediation_type) => {
       if (env.CROWDSECCFBOUNCERDB !== undefined) {
-        let parameters = [metricName, origin || "", remediation_type || "", ipType]
-        let query = `
-          INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
-          VALUES (1, ?, ?, ?, ?)
-          ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
-        `;
+        try {
+          let parameters = [metricName, origin || "", remediation_type || "", ipType]
+          let query = `
+            INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
+            VALUES (1, ?, ?, ?, ?)
+            ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
+          `;
 
-        await env.CROWDSECCFBOUNCERDB
-          .prepare(query)
-          .bind(...parameters)
-          .run();
+          await env.CROWDSECCFBOUNCERDB
+            .prepare(query)
+            .bind(...parameters)
+            .run();
+        } catch (e) {
+          console.error('Failed to write metrics to D1, continuing:', e.message);
+        }
 
       };
     }

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -250,17 +250,21 @@ export default {
 
     const incrementMetrics = async (metricName, ipType, origin, remediation_type) => {
       if (env.CROWDSECCFBOUNCERDB !== undefined) {
-        let parameters = [metricName, origin || "", remediation_type || "", ipType]
-        let query = `
-          INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
-          VALUES (1, ?, ?, ?, ?)
-          ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
-        `;
+        try {
+          let parameters = [metricName, origin || "", remediation_type || "", ipType]
+          let query = `
+            INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
+            VALUES (1, ?, ?, ?, ?)
+            ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
+          `;
 
-        await env.CROWDSECCFBOUNCERDB
-          .prepare(query)
-          .bind(...parameters)
-          .run();
+          await env.CROWDSECCFBOUNCERDB
+            .prepare(query)
+            .bind(...parameters)
+            .run();
+        } catch (e) {
+          console.error('Failed to write metrics to D1, continuing:', e.message);
+        }
 
       };
     }


### PR DESCRIPTION
## Summary

`incrementMetrics` had no error handling around the D1 write. Any D1 unavailability (service disruption, quota, permissions) caused unhandled rejections that propagated to the `fetch` handler, returning 500 to end users. D1 metrics are not in the critical enforcement path.

## Changes

- Wrap `env.CROWDSECCFBOUNCERDB.prepare().bind().run()` in try/catch
- Log error and continue serving the request

Closes #15

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
