### PR TITLE
fix: fail closed on KV read errors instead of silently passing through (closes #17)

### DIFF
--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7116,13 +7116,7 @@ const handleTurnstilePost = async (request, body, turnstile_secret, zoneForThisR
 }
 
 const getFromKV = async (kv, key) => {
-  try {
-    const value = await kv.get(key);
-    return value;
-  } catch (e) {
-    console.log(e)
-    return null
-  }
+  return await kv.get(key);
 }
 
 const writeToKV = async (kv, key, value) => {
@@ -7327,7 +7321,13 @@ const writeToKV = async (kv, key, value) => {
     await incrementMetrics("processed", ipType)
 
 
-    let remediation = await getRemediationForRequest(request, env)
+    let remediation;
+    try {
+      remediation = await getRemediationForRequest(request, env)
+    } catch (e) {
+      console.error("KV lookup failed, failing closed:", e.message);
+      return new Response("Service temporarily unavailable", { status: 503 });
+    }
     if (remediation === null) {
       console.log("No remediation found for request")
       return fetch(request)

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -60,13 +60,7 @@ const handleTurnstilePost = async (request, body, turnstile_secret, zoneForThisR
 }
 
 const getFromKV = async (kv, key) => {
-  try {
-    const value = await kv.get(key);
-    return value;
-  } catch (e) {
-    console.log(e)
-    return null
-  }
+  return await kv.get(key);
 }
 
 const writeToKV = async (kv, key, value) => {
@@ -271,7 +265,13 @@ export default {
     await incrementMetrics("processed", ipType)
 
 
-    let remediation = await getRemediationForRequest(request, env)
+    let remediation;
+    try {
+      remediation = await getRemediationForRequest(request, env)
+    } catch (e) {
+      console.error("KV lookup failed, failing closed:", e.message);
+      return new Response("Service temporarily unavailable", { status: 503 });
+    }
     if (remediation === null) {
       console.log("No remediation found for request")
       return fetch(request)


### PR DESCRIPTION
## Summary

`getFromKV` caught all KV errors and returned `null`, which all callers treated as "no decision found." During any Cloudflare KV service degradation, all banned IPs silently regained access (fail-open in a security enforcement component).

## Changes

- Remove try/catch from `getFromKV` — let KV errors propagate
- Add try/catch around `getRemediationForRequest` in the fetch handler
- Return 503 (Service Temporarily Unavailable) on KV read errors (fail-closed)

Note: This changes the fail mode from open to closed. The Cloudflare Worker route fail mode setting (`fail_open: true/false`) controls what happens when the *Worker itself* is down. This fix controls what happens when KV is down but the Worker is running.

## Test plan

- Simulate KV unavailability — verify 503 returned instead of pass-through
- Verify normal KV reads still work (null for missing keys, values for existing)
- Verify non-enforcement KV reads (e.g., TURNSTILE_CONFIG, BAN_TEMPLATE) behavior is acceptable

Closes #17

_Upstream candidate: this PR can be opened against crowdsecurity/cs-cloudflare-worker-bouncer when ready._
