### PR TITLE
Feat/migrate d1 to analytics engine

### DIFF
--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -66,7 +66,19 @@ type CloudflareWorkerCreateParams struct {
 	LogOnly                 bool     `yaml:"log_only"`
 	KVNameSpaceName         string   `yaml:"kv_namespace_name,omitempty"`          // CF resource title used for create/delete lookup; change when sharing a Cloudflare account with another bouncer instance
 	AnalyticsDataset        string   `yaml:"analytics_dataset,omitempty"`          // CF Analytics Engine dataset name for metrics
-	DecisionsSyncScriptName string   `yaml:"decisions_sync_script_name,omitempty"` // CF worker script name; change when sharing a Cloudflare account with another bouncer instance
+	DecisionsSyncScriptName string                    `yaml:"decisions_sync_script_name,omitempty"` // CF worker script name; change when sharing a Cloudflare account with another bouncer instance
+	Observability           *WorkerObservabilityConfig `yaml:"observability,omitempty"`              // Workers Observability (logs + traces); nil = skip
+}
+
+type WorkerObservabilityConfig struct {
+	Enabled          *bool                `yaml:"enabled"`
+	HeadSamplingRate *float64             `yaml:"head_sampling_rate"`
+	Traces           *WorkerTracesConfig  `yaml:"traces,omitempty"`
+}
+
+type WorkerTracesConfig struct {
+	Enabled          *bool    `yaml:"enabled"`
+	HeadSamplingRate *float64 `yaml:"head_sampling_rate"`
 }
 
 func (w *CloudflareWorkerCreateParams) setDefaults() {
@@ -197,7 +209,7 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 		}
 
 		for _, zone := range account.ZoneConfigs {
-			if !stringSliceContains(zone.Actions, zone.DefaultAction) {
+			if !slices.Contains(zone.Actions, zone.DefaultAction) {
 				zone.Actions = append(zone.Actions, zone.DefaultAction)
 			}
 			if len(zone.Actions) == 0 {
@@ -218,11 +230,19 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 		}
 	}
 	config.CloudflareConfig.Worker.setDefaults() // set defaults for worker
-	return config, nil
-}
 
-func stringSliceContains(slice []string, t string) bool {
-	return slices.Contains(slice, t)
+	if obs := config.CloudflareConfig.Worker.Observability; obs != nil {
+		if r := obs.HeadSamplingRate; r != nil && (*r < 0 || *r > 1) {
+			return nil, fmt.Errorf("observability head_sampling_rate must be between 0 and 1, got %f", *r)
+		}
+		if obs.Traces != nil {
+			if r := obs.Traces.HeadSamplingRate; r != nil && (*r < 0 || *r > 1) {
+				return nil, fmt.Errorf("observability traces head_sampling_rate must be between 0 and 1, got %f", *r)
+			}
+		}
+	}
+
+	return config, nil
 }
 
 func lineComment(l string, zoneByID map[string]cloudflare.Zone, accountByID map[string]cloudflare.Account) string {

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -22,11 +22,11 @@ var (
 	ErrEmptyConfig            = errors.New("empty config")
 )
 
-// KVWorkerBindingName and D1WorkerBindingName are the worker env binding names hardcoded in the
+// KVWorkerBindingName and AEWorkerBindingName are the worker env binding names hardcoded in the
 // compiled worker JS. They must not be changed without also updating the worker source.
 const (
 	KVWorkerBindingName = "CROWDSECCFBOUNCERNS"
-	D1WorkerBindingName = "CROWDSECCFBOUNCERDB"
+	AEWorkerBindingName = "CROWDSECCFBOUNCER_AE"
 )
 
 type TurnstileConfig struct {
@@ -65,7 +65,7 @@ type CloudflareWorkerCreateParams struct {
 	CompatibilityFlags      []string `yaml:"compatibility_flags"`
 	LogOnly                 bool     `yaml:"log_only"`
 	KVNameSpaceName         string   `yaml:"kv_namespace_name,omitempty"`          // CF resource title used for create/delete lookup; change when sharing a Cloudflare account with another bouncer instance
-	D1DBName                string   `yaml:"d1_db_name,omitempty"`                 // CF D1 database name used for create/delete lookup; change when sharing a Cloudflare account with another bouncer instance
+	AnalyticsDataset        string   `yaml:"analytics_dataset,omitempty"`          // CF Analytics Engine dataset name for metrics
 	DecisionsSyncScriptName string   `yaml:"decisions_sync_script_name,omitempty"` // CF worker script name; change when sharing a Cloudflare account with another bouncer instance
 }
 
@@ -76,15 +76,15 @@ func (w *CloudflareWorkerCreateParams) setDefaults() {
 	if w.KVNameSpaceName == "" {
 		w.KVNameSpaceName = "CROWDSECCFBOUNCERNS"
 	}
-	if w.D1DBName == "" {
-		w.D1DBName = "CROWDSECCFBOUNCERDB"
+	if w.AnalyticsDataset == "" {
+		w.AnalyticsDataset = "crowdsec_cloudflare_bouncer"
 	}
 	if w.DecisionsSyncScriptName == "" {
 		w.DecisionsSyncScriptName = "crowdsec-decisions-sync-worker"
 	}
 }
 
-func (w *CloudflareWorkerCreateParams) CreateWorkerParams(workerScript string, id string, varActionsForZoneByDomain []byte, dbID string) cloudflare.CreateWorkerParams {
+func (w *CloudflareWorkerCreateParams) CreateWorkerParams(workerScript string, id string, varActionsForZoneByDomain []byte, accountName string) cloudflare.CreateWorkerParams {
 	bindings := map[string]cloudflare.WorkerBinding{
 		KVWorkerBindingName: cloudflare.WorkerKvNamespaceBinding{NamespaceID: id},
 		VarNameForActionsByDomain: cloudflare.WorkerPlainTextBinding{
@@ -93,12 +93,12 @@ func (w *CloudflareWorkerCreateParams) CreateWorkerParams(workerScript string, i
 		"LOG_ONLY": cloudflare.WorkerPlainTextBinding{
 			Text: fmt.Sprintf("%t", w.LogOnly),
 		},
-	}
-
-	if dbID != "" {
-		bindings[D1WorkerBindingName] = cloudflare.WorkerD1DatabaseBinding{
-			DatabaseID: dbID,
-		}
+		AEWorkerBindingName: cloudflare.WorkerAnalyticsEngineBinding{
+			Dataset: w.AnalyticsDataset,
+		},
+		"ACCOUNT_NAME": cloudflare.WorkerPlainTextBinding{
+			Text: accountName,
+		},
 	}
 	return cloudflare.CreateWorkerParams{
 		Script:             workerScript,

--- a/pkg/cfg/config_test.go
+++ b/pkg/cfg/config_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"path"
+	"strings"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/crowdsecurity/crowdsec-cloudflare-worker-bouncer/pkg/cfg"
 )
 
@@ -44,5 +46,182 @@ func TestConfig(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestCreateWorkerParams_AEBinding(t *testing.T) {
+	w := &cfg.CloudflareWorkerCreateParams{
+		AnalyticsDataset: "crowdsec_cloudflare_bouncer",
+	}
+
+	params := w.CreateWorkerParams("script", "kv-ns-id", []byte(`{}`), "test-account")
+
+	binding, ok := params.Bindings[cfg.AEWorkerBindingName]
+	if !ok {
+		t.Fatal("AE binding missing from CreateWorkerParams")
+	}
+
+	aeBinding, ok := binding.(cloudflare.WorkerAnalyticsEngineBinding)
+	if !ok {
+		t.Fatalf("AE binding is %T, want WorkerAnalyticsEngineBinding", binding)
+	}
+
+	if aeBinding.Dataset != "crowdsec_cloudflare_bouncer" {
+		t.Fatalf("AE dataset = %q, want %q", aeBinding.Dataset, "crowdsec_cloudflare_bouncer")
+	}
+}
+
+func TestCreateWorkerParams_AccountNameBinding(t *testing.T) {
+	w := &cfg.CloudflareWorkerCreateParams{}
+
+	params := w.CreateWorkerParams("script", "kv-ns-id", []byte(`{}`), "Ray's Account")
+
+	binding, ok := params.Bindings["ACCOUNT_NAME"]
+	if !ok {
+		t.Fatal("ACCOUNT_NAME binding missing from CreateWorkerParams")
+	}
+
+	ptBinding, ok := binding.(cloudflare.WorkerPlainTextBinding)
+	if !ok {
+		t.Fatalf("ACCOUNT_NAME binding is %T, want WorkerPlainTextBinding", binding)
+	}
+
+	if ptBinding.Text != "Ray's Account" {
+		t.Fatalf("ACCOUNT_NAME = %q, want %q", ptBinding.Text, "Ray's Account")
+	}
+}
+
+func TestSetDefaults_AnalyticsDataset(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	config, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	if config.CloudflareConfig.Worker.AnalyticsDataset != "crowdsec_cloudflare_bouncer" {
+		t.Fatalf("AnalyticsDataset = %q, want %q", config.CloudflareConfig.Worker.AnalyticsDataset, "crowdsec_cloudflare_bouncer")
+	}
+}
+
+func TestObservabilityConfig_NilByDefault(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	config, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	if config.CloudflareConfig.Worker.Observability != nil {
+		t.Fatal("Observability should be nil by default")
+	}
+}
+
+func TestObservabilityConfig_ParsesFromYAML(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  worker:
+    observability:
+      enabled: true
+      head_sampling_rate: 0.5
+      traces:
+        enabled: true
+        head_sampling_rate: 0.1
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	config, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	obs := config.CloudflareConfig.Worker.Observability
+	if obs == nil {
+		t.Fatal("Observability should not be nil")
+	}
+	if obs.Enabled == nil || !*obs.Enabled {
+		t.Error("Enabled should be true")
+	}
+	if obs.HeadSamplingRate == nil || *obs.HeadSamplingRate != 0.5 {
+		t.Errorf("HeadSamplingRate = %v, want 0.5", obs.HeadSamplingRate)
+	}
+
+	if obs.Traces == nil {
+		t.Fatal("Traces should not be nil")
+	}
+	if obs.Traces.Enabled == nil || !*obs.Traces.Enabled {
+		t.Error("Traces.Enabled should be true")
+	}
+	if obs.Traces.HeadSamplingRate == nil || *obs.Traces.HeadSamplingRate != 0.1 {
+		t.Errorf("Traces.HeadSamplingRate = %v, want 0.1", obs.Traces.HeadSamplingRate)
+	}
+}
+
+func TestObservabilityConfig_InvalidSamplingRate(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  worker:
+    observability:
+      enabled: true
+      head_sampling_rate: 5.0
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	_, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err == nil {
+		t.Fatal("expected error for invalid sampling rate")
+	}
+	if !strings.Contains(err.Error(), "head_sampling_rate must be between 0 and 1") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -1,11 +1,13 @@
 package cf
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -27,9 +29,6 @@ var workerScript string
 
 //go:embed decisions-sync-worker/dist/main.js
 var decisionsSyncWorkerScript string
-
-//go:embed metrics.sql
-var sqlCreateTableStatement string
 
 const (
 	WidgetName            = "crowdsec-cloudflare-worker-bouncer-widget"
@@ -58,10 +57,10 @@ type cloudflareAPI interface {
 	UploadWorker(ctx context.Context, rc *cf.ResourceContainer, params cf.CreateWorkerParams) (cf.WorkerScriptResponse, error)
 	UpdateWorkerCronTriggers(ctx context.Context, rc *cf.ResourceContainer, params cf.UpdateWorkerCronTriggersParams) ([]cf.WorkerCronTrigger, error)
 	WriteWorkersKVEntries(ctx context.Context, rc *cf.ResourceContainer, params cf.WriteWorkersKVEntriesParams) (cf.Response, error)
-	CreateD1Database(ctx context.Context, rc *cf.ResourceContainer, params cf.CreateD1DatabaseParams) (cf.D1Database, error)
+	// Legacy D1 methods — retained for one release cycle to clean up orphaned D1 databases
+	// from pre-Analytics-Engine versions. Remove after next release.
 	DeleteD1Database(ctx context.Context, rc *cf.ResourceContainer, databaseID string) error
 	ListD1Databases(ctx context.Context, rc *cf.ResourceContainer, params cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error)
-	QueryD1Database(ctx context.Context, rc *cf.ResourceContainer, params cf.QueryD1DatabaseParams) ([]cf.D1Result, error)
 }
 
 type CloudflareAccountManager struct {
@@ -71,12 +70,11 @@ type CloudflareAccountManager struct {
 	logger                *log.Entry
 	hasIPRangeKV          bool
 	NamespaceID           string
-	DatabaseID            string
 	KVPairByDecisionValue map[string]cf.WorkersKVPair
 	ipRangeKVPair         cf.WorkersKVPair
 	ActionByIPRange       map[string]string
 	Worker                *cfg.CloudflareWorkerCreateParams
-	hasD1Access           bool
+	lastMetricsPoll       time.Time
 }
 
 // This function creates a new instance of the CloudflareAccountManager struct,
@@ -165,34 +163,8 @@ func (m *CloudflareAccountManager) DeployInfra() error {
 	m.logger.Tracef("KVNS: %+v", kvNSResp)
 	m.NamespaceID = kvNSResp.Result.ID
 
-	//Create the database
-	m.logger.Info("Creating D1 Database for metrics")
-
-	databaseResp, err := m.api.CreateD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.CreateD1DatabaseParams{
-		Name: m.Worker.D1DBName,
-	})
-
-	//This could probably be a check on a more specific error, but because metrics are not critical, we just log the error and continue
-	if err != nil {
-		m.logger.Warnf("Error while creating D1 DB: %s. Remediation component won't be able to send metrics to crowdsec. Make sure your token has the proper permissions.", err)
-		m.hasD1Access = false
-	} else {
-		m.hasD1Access = true
-	}
-
-	if m.hasD1Access {
-		m.DatabaseID = databaseResp.UUID
-
-		_, err = m.api.QueryD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.QueryD1DatabaseParams{
-			DatabaseID: m.DatabaseID,
-			SQL:        sqlCreateTableStatement,
-			Parameters: []string{},
-		})
-
-		if err != nil {
-			return fmt.Errorf("error while creating D1 DB table, make sure your token has the proper permissions: %w", err)
-		}
-	}
+	// Initialize metrics polling window (AE datasets auto-create on first write)
+	m.lastMetricsPoll = time.Now().UTC().Add(-2 * time.Minute)
 
 	var banTemplate []byte
 	if m.AccountCfg.BanTemplate != "" {
@@ -228,7 +200,7 @@ func (m *CloudflareAccountManager) DeployInfra() error {
 
 	m.logger.Infof("Creating worker %s", m.Worker.ScriptName)
 
-	worker, err := m.api.UploadWorker(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), m.Worker.CreateWorkerParams(workerScript, kvNSResp.Result.ID, varActionsForZoneByDomain, m.DatabaseID))
+	worker, err := m.api.UploadWorker(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), m.Worker.CreateWorkerParams(workerScript, kvNSResp.Result.ID, varActionsForZoneByDomain, m.AccountCfg.Name))
 	m.logger.Tracef("Worker: %+v", worker)
 
 	if err != nil {
@@ -461,35 +433,27 @@ func (m *CloudflareAccountManager) cleanupKVNamespaces() error {
 	return nil
 }
 
-func (m *CloudflareAccountManager) cleanupD1Databases(start bool) error {
-	if !m.hasD1Access && !start {
-		return nil
-	}
-
-	m.logger.Debugf("Listing D1 DBs")
+// cleanupLegacyD1Databases removes D1 databases from pre-Analytics-Engine versions.
+// This is a one-release migration shim — remove after the next release.
+func (m *CloudflareAccountManager) cleanupLegacyD1Databases() {
+	m.logger.Debug("Checking for legacy D1 databases to clean up")
 	dbs, _, err := m.api.ListD1Databases(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.ListD1DatabasesParams{})
-
 	if err != nil {
-		if !start {
-			return fmt.Errorf("error while listing D1 DBs, make sure your token has the proper permissions: %w", err)
-		}
-		dbs = []cf.D1Database{}
+		m.logger.Debugf("Could not list D1 databases (token may lack D1:Edit scope): %s", err)
+		return
 	}
 
-	m.logger.Tracef("dbs: %+v", dbs)
-
+	legacyName := "CROWDSECCFBOUNCERDB"
 	for _, db := range dbs {
-		m.logger.Debugf("Checking D1 DB %s vs %s", db.Name, m.Worker.D1DBName)
-		if db.Name == m.Worker.D1DBName {
-			m.logger.Debugf("Deleting D1 DB %s", db.UUID)
-			err = m.api.DeleteD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), db.UUID)
-			if err != nil {
-				return fmt.Errorf("error while deleting D1 DB %s, make sure your token has the proper permissions: %w", db.UUID, err)
+		if db.Name == legacyName {
+			m.logger.Infof("Deleting legacy D1 database %s (%s)", db.Name, db.UUID)
+			if err := m.api.DeleteD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), db.UUID); err != nil {
+				m.logger.Warnf("Failed to delete legacy D1 database %s: %s (delete manually via Cloudflare dashboard)", db.UUID, err)
+			} else {
+				m.logger.Infof("Deleted legacy D1 database %s", db.UUID)
 			}
-			m.logger.Debugf("Deleted D1 DB %s", db.UUID)
 		}
 	}
-	return nil
 }
 
 // This function checks and destroys the cloudflare infrastructure which could have been deployed by the worker in past.
@@ -513,8 +477,10 @@ func (m *CloudflareAccountManager) CleanUpExistingWorkers(start bool) error {
 		return err
 	}
 
-	if err := m.cleanupD1Databases(start); err != nil {
-		return err
+	// Migration shim: clean up D1 databases from pre-Analytics-Engine versions.
+	// Remove this block after one release cycle.
+	if start {
+		m.cleanupLegacyD1Databases()
 	}
 
 	m.logger.Info("Done cleaning up existing workers")
@@ -837,66 +803,98 @@ func (m *CloudflareAccountManager) HandleTurnstile() error {
 	return g.Wait()
 }
 
-func (m *CloudflareAccountManager) UpdateMetrics() error {
-	m.logger.Debug("Getting metrics")
-	if !m.hasD1Access {
-		m.logger.Debug("No D1 access, skipping metrics update")
-		return nil
-	}
-	resp, err := m.api.QueryD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.QueryD1DatabaseParams{
-		DatabaseID: m.DatabaseID,
-		SQL:        "SELECT * FROM metrics",
-		Parameters: []string{},
-	})
-	if err != nil {
-		return err
-	}
-	m.logger.Tracef("resp: %+v", resp)
+// aeQueryResult represents the JSON response from the Analytics Engine SQL API.
+type aeQueryResult struct {
+	Meta []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"meta"`
+	Data []map[string]any `json:"data"`
+	Rows int              `json:"rows"`
+}
 
-	for _, r := range resp {
-		if r.Success == nil || !*r.Success {
-			m.logger.Warnf("Query failed: %+v", r)
-			continue
-		}
-		for _, data := range r.Results {
-			switch data["metric_name"] {
-			case "processed":
-				val, ok := data["val"].(float64)
-				if !ok {
-					m.logger.Warnf("Invalid value for processed metric: %+v", data)
-					continue
-				}
-				ipType, ok := data["ip_type"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for ip_type: %+v", data)
-					continue
-				}
-				metrics.TotalProcessedRequests.With(prometheus.Labels{"ip_type": ipType, "account": m.AccountCfg.Name}).Set(val)
-			case "dropped":
-				val, ok := data["val"].(float64)
-				if !ok {
-					m.logger.Warnf("Invalid value for dropped metric: %+v", data)
-					continue
-				}
-				origin, ok := data["origin"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for origin: %+v", data)
-					continue
-				}
-				ipType, ok := data["ip_type"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for ip_type: %+v", data)
-					continue
-				}
-				remediation, ok := data["remediation_type"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for remediation: %+v", data)
-					continue
-				}
-				metrics.TotalBlockedRequests.With(prometheus.Labels{"origin": origin, "remediation": remediation, "ip_type": ipType, "account": m.AccountCfg.Name}).Set(val)
-			default:
-				m.logger.Warnf("Unknown metric: %+v", data)
-			}
+func (m *CloudflareAccountManager) queryAnalyticsEngine(query string) (*aeQueryResult, error) {
+	url := fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/analytics_engine/sql", m.AccountCfg.ID)
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal AE query: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(m.Ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AE request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.AccountCfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("AE query failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read AE response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("AE query returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result aeQueryResult
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse AE response: %w", err)
+	}
+	return &result, nil
+}
+
+func (m *CloudflareAccountManager) UpdateMetrics() error {
+	m.logger.Debug("Getting metrics from Analytics Engine")
+	now := time.Now().UTC()
+
+	query := fmt.Sprintf(`SELECT
+		blob1 AS metric_name,
+		blob2 AS ip_type,
+		blob3 AS origin,
+		blob4 AS remediation_type,
+		SUM(_sample_interval * double1) AS val
+	FROM %s
+	WHERE timestamp > toDateTime('%s')
+		AND index1 = '%s'
+	GROUP BY metric_name, ip_type, origin, remediation_type
+	FORMAT JSON`,
+		m.Worker.AnalyticsDataset,
+		m.lastMetricsPoll.Format("2006-01-02 15:04:05"),
+		m.AccountCfg.Name,
+	)
+
+	result, err := m.queryAnalyticsEngine(query)
+	if err != nil {
+		return fmt.Errorf("unable to query Analytics Engine: %w", err)
+	}
+	m.lastMetricsPoll = now
+	m.logger.Tracef("AE result: %+v", result)
+
+	for _, row := range result.Data {
+		metricName, _ := row["metric_name"].(string)
+		ipType, _ := row["ip_type"].(string)
+		origin, _ := row["origin"].(string)
+		remediation, _ := row["remediation_type"].(string)
+		val, _ := row["val"].(float64)
+
+		switch metricName {
+		case "processed":
+			metrics.TotalProcessedRequests.With(prometheus.Labels{
+				"ip_type": ipType, "account": m.AccountCfg.Name,
+			}).Add(val)
+		case "dropped":
+			metrics.TotalBlockedRequests.With(prometheus.Labels{
+				"origin": origin, "remediation": remediation,
+				"ip_type": ipType, "account": m.AccountCfg.Name,
+			}).Add(val)
+		default:
+			m.logger.Warnf("Unknown metric from AE: %s", metricName)
 		}
 	}
 

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -74,7 +74,10 @@ type CloudflareAccountManager struct {
 	ipRangeKVPair         cf.WorkersKVPair
 	ActionByIPRange       map[string]string
 	Worker                *cfg.CloudflareWorkerCreateParams
+	httpClient            *http.Client
 	lastMetricsPoll       time.Time
+	metricsMu             sync.Mutex
+	cumulativeMetrics     map[string]float64
 }
 
 // This function creates a new instance of the CloudflareAccountManager struct,
@@ -111,6 +114,12 @@ func NewCloudflareManager(ctx context.Context, accountCfg cfg.AccountConfig, wor
 		ipRangeKVPair:   cf.WorkersKVPair{Key: IpRangeKeyName, Value: "{}"},
 		ActionByIPRange: make(map[string]string),
 		Worker:          worker,
+		httpClient: &http.Client{
+			Transport: &CloudflareManagerHTTPTransport{accountName: accountCfg.Name},
+			Timeout:   30 * time.Second,
+		},
+		lastMetricsPoll:   time.Now().UTC().Add(-2 * time.Minute),
+		cumulativeMetrics: make(map[string]float64),
 	}, nil
 }
 
@@ -144,6 +153,83 @@ func NewCloudflareAPI(accountCfg cfg.AccountConfig) (cloudflareAPI, error) {
 type ActionsForZone struct {
 	SupportedActions []string `json:"supported_actions"`
 	DefaultAction    string   `json:"default_action"`
+}
+
+// enableWorkerObservability PATCHes the script-settings API to enable Workers
+// Observability (logs + traces). This is a direct HTTP call because cloudflare-go
+// v0.116.0 does not expose the observability field.
+func (m *CloudflareAccountManager) enableWorkerObservability(scriptName string) error {
+	obsCfg := m.Worker.Observability
+	if obsCfg == nil {
+		return nil
+	}
+
+	enabled := true
+	if obsCfg.Enabled != nil {
+		enabled = *obsCfg.Enabled
+	}
+
+	samplingRate := 1.0
+	if obsCfg.HeadSamplingRate != nil {
+		samplingRate = *obsCfg.HeadSamplingRate
+	}
+
+	type tracesPayload struct {
+		Enabled          bool    `json:"enabled"`
+		HeadSamplingRate float64 `json:"head_sampling_rate"`
+	}
+	type obsPayload struct {
+		Enabled          bool           `json:"enabled"`
+		HeadSamplingRate float64        `json:"head_sampling_rate"`
+		Traces           tracesPayload  `json:"traces"`
+	}
+
+	// Default traces to match top-level settings; override if explicitly configured
+	traces := tracesPayload{Enabled: enabled, HeadSamplingRate: samplingRate}
+	if obsCfg.Traces != nil {
+		if obsCfg.Traces.Enabled != nil {
+			traces.Enabled = *obsCfg.Traces.Enabled
+		}
+		if obsCfg.Traces.HeadSamplingRate != nil {
+			traces.HeadSamplingRate = *obsCfg.Traces.HeadSamplingRate
+		}
+	}
+
+	payload, err := json.Marshal(struct {
+		Observability obsPayload `json:"observability"`
+	}{Observability: obsPayload{
+		Enabled:          enabled,
+		HeadSamplingRate: samplingRate,
+		Traces:           traces,
+	}})
+	if err != nil {
+		return fmt.Errorf("failed to marshal observability payload: %w", err)
+	}
+
+	url := fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/workers/scripts/%s/script-settings",
+		m.AccountCfg.ID, scriptName)
+
+	req, err := http.NewRequestWithContext(m.Ctx, http.MethodPatch, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create observability request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.AccountCfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("observability settings request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("observability settings HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	m.logger.Infof("Configured observability for %s (logs=%t/%.2f, traces=%t/%.2f)",
+		scriptName, enabled, samplingRate, traces.Enabled, traces.HeadSamplingRate)
+	return nil
 }
 
 // Creates a new Cloudflare Workers KV namespace, uploads a new worker script, and binds the worker to one or more routes for
@@ -205,6 +291,10 @@ func (m *CloudflareAccountManager) DeployInfra() error {
 
 	if err != nil {
 		return err
+	}
+
+	if err := m.enableWorkerObservability(m.Worker.ScriptName); err != nil {
+		return fmt.Errorf("failed to enable observability for %s: %w", m.Worker.ScriptName, err)
 	}
 
 	zg := errgroup.Group{}
@@ -296,6 +386,10 @@ func (m *CloudflareAccountManager) DeployDecisionsSyncWorker(crowdSecConfig cfg.
 		return fmt.Errorf("failed to upload decisions sync worker: %w", err)
 	}
 	m.logger.Tracef("Decisions sync worker: %+v", worker)
+
+	if err := m.enableWorkerObservability(m.Worker.DecisionsSyncScriptName); err != nil {
+		return fmt.Errorf("failed to enable observability for %s: %w", m.Worker.DecisionsSyncScriptName, err)
+	}
 
 	// Deploy cron trigger for the decisions sync worker
 	m.logger.Infof("Deploying cron trigger for decisions sync worker: %s", cronSchedule)
@@ -803,31 +897,30 @@ func (m *CloudflareAccountManager) HandleTurnstile() error {
 	return g.Wait()
 }
 
+// aeQueryMeta describes a column returned by the Analytics Engine SQL API.
+type aeQueryMeta struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
 // aeQueryResult represents the JSON response from the Analytics Engine SQL API.
 type aeQueryResult struct {
-	Meta []struct {
-		Name string `json:"name"`
-		Type string `json:"type"`
-	} `json:"meta"`
+	Meta []aeQueryMeta    `json:"meta"`
 	Data []map[string]any `json:"data"`
 	Rows int              `json:"rows"`
 }
 
 func (m *CloudflareAccountManager) queryAnalyticsEngine(query string) (*aeQueryResult, error) {
 	url := fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/analytics_engine/sql", m.AccountCfg.ID)
-	body, err := json.Marshal(map[string]string{"query": query})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal AE query: %w", err)
-	}
 
-	req, err := http.NewRequestWithContext(m.Ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(m.Ctx, http.MethodPost, url, strings.NewReader(query))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AE request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+m.AccountCfg.Token)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "text/plain")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("AE query failed: %w", err)
 	}
@@ -850,9 +943,17 @@ func (m *CloudflareAccountManager) queryAnalyticsEngine(query string) (*aeQueryR
 }
 
 func (m *CloudflareAccountManager) UpdateMetrics() error {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+
 	m.logger.Debug("Getting metrics from Analytics Engine")
 	now := time.Now().UTC()
 
+	// Escape single quotes to prevent query breakage (e.g. "Ray's Account")
+	safeName := strings.ReplaceAll(m.AccountCfg.Name, "'", "\\'")
+
+	// AE blob field mapping (must match writeMetricEvent in worker.js):
+	//   blob1 = metric_name, blob2 = ip_type, blob3 = origin, blob4 = remediation_type
 	query := fmt.Sprintf(`SELECT
 		blob1 AS metric_name,
 		blob2 AS ip_type,
@@ -866,7 +967,7 @@ func (m *CloudflareAccountManager) UpdateMetrics() error {
 	FORMAT JSON`,
 		m.Worker.AnalyticsDataset,
 		m.lastMetricsPoll.Format("2006-01-02 15:04:05"),
-		m.AccountCfg.Name,
+		safeName,
 	)
 
 	result, err := m.queryAnalyticsEngine(query)
@@ -877,22 +978,41 @@ func (m *CloudflareAccountManager) UpdateMetrics() error {
 	m.logger.Tracef("AE result: %+v", result)
 
 	for _, row := range result.Data {
-		metricName, _ := row["metric_name"].(string)
-		ipType, _ := row["ip_type"].(string)
-		origin, _ := row["origin"].(string)
-		remediation, _ := row["remediation_type"].(string)
-		val, _ := row["val"].(float64)
+		metricName, ok := row["metric_name"].(string)
+		if !ok {
+			m.logger.Warnf("Invalid metric_name type in AE response: %T", row["metric_name"])
+			continue
+		}
+		val, ok := row["val"].(float64)
+		if !ok {
+			m.logger.Warnf("Invalid val type in AE response for metric %s: %T", metricName, row["val"])
+			continue
+		}
+		var ipType, origin, remediation string
+		if v, ok := row["ip_type"].(string); ok {
+			ipType = v
+		}
+		if v, ok := row["origin"].(string); ok {
+			origin = v
+		}
+		if v, ok := row["remediation_type"].(string); ok {
+			remediation = v
+		}
 
 		switch metricName {
 		case "processed":
+			key := "processed:" + ipType + ":" + m.AccountCfg.Name
+			m.cumulativeMetrics[key] += val
 			metrics.TotalProcessedRequests.With(prometheus.Labels{
 				"ip_type": ipType, "account": m.AccountCfg.Name,
-			}).Add(val)
+			}).Set(m.cumulativeMetrics[key])
 		case "dropped":
+			key := "dropped:" + origin + ":" + remediation + ":" + ipType + ":" + m.AccountCfg.Name
+			m.cumulativeMetrics[key] += val
 			metrics.TotalBlockedRequests.With(prometheus.Labels{
 				"origin": origin, "remediation": remediation,
 				"ip_type": ipType, "account": m.AccountCfg.Name,
-			}).Add(val)
+			}).Set(m.cumulativeMetrics[key])
 		default:
 			m.logger.Warnf("Unknown metric from AE: %s", metricName)
 		}

--- a/pkg/cloudflare/cloudflare_test.go
+++ b/pkg/cloudflare/cloudflare_test.go
@@ -1,0 +1,830 @@
+package cf
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cf "github.com/cloudflare/cloudflare-go"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/crowdsecurity/crowdsec-cloudflare-worker-bouncer/pkg/cfg"
+	"github.com/crowdsecurity/crowdsec-cloudflare-worker-bouncer/pkg/metrics"
+)
+
+// --- Test Infrastructure ---
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func gaugeValue(g prometheus.Gauge) float64 {
+	m := &dto.Metric{}
+	if err := g.Write(m); err != nil {
+		panic("failed to read gauge: " + err.Error())
+	}
+	return m.GetGauge().GetValue()
+}
+
+func makeAEResponseClient(data []map[string]any) *http.Client {
+	result := aeQueryResult{Data: data, Rows: len(data)}
+	respBody, err := json.Marshal(&result)
+	if err != nil {
+		panic("makeAEResponseClient: " + err.Error())
+	}
+	body := string(respBody)
+	return &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			_, _ = io.ReadAll(r.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+}
+
+func makeAEErrorClient(statusCode int, body string) *http.Client {
+	return &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			_, _ = io.ReadAll(r.Body)
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+}
+
+type capturedRequest struct {
+	Request *http.Request
+	Body    string
+}
+
+func captureRequestClient(responseBody string) (*http.Client, *capturedRequest) {
+	captured := &capturedRequest{}
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			captured.Request = r
+			body, _ := io.ReadAll(r.Body)
+			captured.Body = string(body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(responseBody)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	return client, captured
+}
+
+func newTestManager() *CloudflareAccountManager {
+	return &CloudflareAccountManager{
+		AccountCfg: cfg.AccountConfig{
+			ID:    "test-account-id",
+			Token: "test-token",
+			Name:  "test-account",
+		},
+		Ctx:    context.Background(),
+		logger: log.WithFields(log.Fields{"account": "test-account"}),
+		Worker: &cfg.CloudflareWorkerCreateParams{
+			AnalyticsDataset: "test_dataset",
+		},
+		httpClient:        &http.Client{},
+		lastMetricsPoll:   time.Now().UTC().Add(-2 * time.Minute),
+		cumulativeMetrics: make(map[string]float64),
+	}
+}
+
+func resetMetrics() {
+	metrics.TotalProcessedRequests.Reset()
+	metrics.TotalBlockedRequests.Reset()
+}
+
+// --- Mock cloudflareAPI ---
+
+type mockCFAPI struct {
+	listD1DatabasesFn  func(context.Context, *cf.ResourceContainer, cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error)
+	deleteD1DatabaseFn func(context.Context, *cf.ResourceContainer, string) error
+	deleteD1Calls      []string
+}
+
+func (*mockCFAPI) Account(_ context.Context, _ string) (cf.Account, cf.ResultInfo, error) {
+	return cf.Account{}, cf.ResultInfo{}, nil
+}
+func (*mockCFAPI) CreateTurnstileWidget(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateTurnstileWidgetParams) (cf.TurnstileWidget, error) {
+	return cf.TurnstileWidget{}, nil
+}
+func (*mockCFAPI) CreateWorkerRoute(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateWorkerRouteParams) (cf.WorkerRouteResponse, error) {
+	return cf.WorkerRouteResponse{}, nil
+}
+func (*mockCFAPI) CreateWorkersKVNamespace(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateWorkersKVNamespaceParams) (cf.WorkersKVNamespaceResponse, error) {
+	return cf.WorkersKVNamespaceResponse{}, nil
+}
+func (*mockCFAPI) DeleteTurnstileWidget(_ context.Context, _ *cf.ResourceContainer, _ string) error {
+	return nil
+}
+func (*mockCFAPI) DeleteWorker(_ context.Context, _ *cf.ResourceContainer, _ cf.DeleteWorkerParams) error {
+	return nil
+}
+func (*mockCFAPI) DeleteWorkerRoute(_ context.Context, _ *cf.ResourceContainer, _ string) (cf.WorkerRouteResponse, error) {
+	return cf.WorkerRouteResponse{}, nil
+}
+func (*mockCFAPI) DeleteWorkersKVEntries(_ context.Context, _ *cf.ResourceContainer, _ cf.DeleteWorkersKVEntriesParams) (cf.Response, error) {
+	return cf.Response{}, nil
+}
+func (*mockCFAPI) DeleteWorkersKVNamespace(_ context.Context, _ *cf.ResourceContainer, _ string) (cf.Response, error) {
+	return cf.Response{}, nil
+}
+func (*mockCFAPI) ListTurnstileWidgets(_ context.Context, _ *cf.ResourceContainer, _ cf.ListTurnstileWidgetParams) ([]cf.TurnstileWidget, *cf.ResultInfo, error) {
+	return nil, nil, nil}
+func (*mockCFAPI) ListWorkerRoutes(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkerRoutesParams) (cf.WorkerRoutesResponse, error) {
+	return cf.WorkerRoutesResponse{}, nil
+}
+func (*mockCFAPI) ListWorkersKVNamespaces(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error) {
+	return nil, nil, nil}
+func (*mockCFAPI) ListWorkersSecrets(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkersSecretsParams) (cf.WorkersListSecretsResponse, error) {
+	return cf.WorkersListSecretsResponse{}, nil
+}
+func (*mockCFAPI) ListZones(_ context.Context, _ ...string) ([]cf.Zone, error) {
+	return nil, nil}
+func (*mockCFAPI) RotateTurnstileWidget(_ context.Context, _ *cf.ResourceContainer, _ cf.RotateTurnstileWidgetParams) (cf.TurnstileWidget, error) {
+	return cf.TurnstileWidget{}, nil
+}
+func (*mockCFAPI) SetWorkersSecret(_ context.Context, _ *cf.ResourceContainer, _ cf.SetWorkersSecretParams) (cf.WorkersPutSecretResponse, error) {
+	return cf.WorkersPutSecretResponse{}, nil
+}
+func (*mockCFAPI) UploadWorker(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateWorkerParams) (cf.WorkerScriptResponse, error) {
+	return cf.WorkerScriptResponse{}, nil
+}
+func (*mockCFAPI) UpdateWorkerCronTriggers(_ context.Context, _ *cf.ResourceContainer, _ cf.UpdateWorkerCronTriggersParams) ([]cf.WorkerCronTrigger, error) {
+	return nil, nil}
+func (*mockCFAPI) WriteWorkersKVEntries(_ context.Context, _ *cf.ResourceContainer, _ cf.WriteWorkersKVEntriesParams) (cf.Response, error) {
+	return cf.Response{}, nil
+}
+func (m *mockCFAPI) ListD1Databases(ctx context.Context, rc *cf.ResourceContainer, params cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+	if m.listD1DatabasesFn != nil {
+		return m.listD1DatabasesFn(ctx, rc, params)
+	}
+	return nil, nil, nil
+}
+func (m *mockCFAPI) DeleteD1Database(ctx context.Context, rc *cf.ResourceContainer, databaseID string) error {
+	m.deleteD1Calls = append(m.deleteD1Calls, databaseID)
+	if m.deleteD1DatabaseFn != nil {
+		return m.deleteD1DatabaseFn(ctx, rc, databaseID)
+	}
+	return nil
+}
+
+// ============================================================
+// Group 1: queryAnalyticsEngine
+// ============================================================
+
+func TestQueryAnalyticsEngine_SendsRawSQL(t *testing.T) {
+	emptyResponse := `{"meta":[],"data":[],"rows":0}`
+	client, captured := captureRequestClient(emptyResponse)
+
+	m := newTestManager()
+	m.httpClient = client
+
+	query := "SELECT blob1 FROM test_dataset FORMAT JSON"
+	_, err := m.queryAnalyticsEngine(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured.Request.Header.Get("Content-Type") != "text/plain" {
+		t.Errorf("Content-Type = %q, want text/plain", captured.Request.Header.Get("Content-Type"))
+	}
+	if captured.Request.Header.Get("Authorization") != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want Bearer test-token", captured.Request.Header.Get("Authorization"))
+	}
+	if captured.Body != query {
+		t.Errorf("body = %q, want raw SQL %q", captured.Body, query)
+	}
+	wantURL := "https://api.cloudflare.com/client/v4/accounts/test-account-id/analytics_engine/sql"
+	if captured.Request.URL.String() != wantURL {
+		t.Errorf("URL = %q, want %q", captured.Request.URL.String(), wantURL)
+	}
+}
+
+func TestQueryAnalyticsEngine_HTTPError(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = makeAEErrorClient(403, "Forbidden: invalid token")
+
+	_, err := m.queryAnalyticsEngine("SELECT 1")
+	if err == nil {
+		t.Fatal("expected error for HTTP 403")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should contain status code 403, got: %v", err)
+	}
+}
+
+func TestQueryAnalyticsEngine_InvalidJSON(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			_, _ = io.ReadAll(r.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("not json")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	_, err := m.queryAnalyticsEngine("SELECT 1")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error should mention parsing, got: %v", err)
+	}
+}
+
+func TestQueryAnalyticsEngine_Success(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "val": 42.0},
+	})
+
+	result, err := m.queryAnalyticsEngine("SELECT 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Rows != 1 {
+		t.Errorf("Rows = %d, want 1", result.Rows)
+	}
+	if len(result.Data) != 1 {
+		t.Fatalf("Data length = %d, want 1", len(result.Data))
+	}
+	if result.Data[0]["metric_name"] != "processed" {
+		t.Errorf("metric_name = %v, want processed", result.Data[0]["metric_name"])
+	}
+}
+
+// ============================================================
+// Group 2: UpdateMetrics
+// ============================================================
+
+func TestUpdateMetrics_HappyPath(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 100.0},
+		{"metric_name": "dropped", "ip_type": "ipv6", "origin": "crowdsec", "remediation_type": "ban", "val": 7.0},
+	})
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("UpdateMetrics failed: %v", err)
+	}
+
+	processed := gaugeValue(metrics.TotalProcessedRequests.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if processed != 100.0 {
+		t.Errorf("processed = %f, want 100", processed)
+	}
+
+	dropped := gaugeValue(metrics.TotalBlockedRequests.With(prometheus.Labels{
+		"origin": "crowdsec", "remediation": "ban", "ip_type": "ipv6", "account": "test-account",
+	}))
+	if dropped != 7.0 {
+		t.Errorf("dropped = %f, want 7", dropped)
+	}
+}
+
+func TestUpdateMetrics_CumulativeTracking(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+
+	// First call: 10 processed
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 10.0},
+		{"metric_name": "dropped", "ip_type": "ipv4", "origin": "crowdsec", "remediation_type": "ban", "val": 3.0},
+	})
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("first UpdateMetrics failed: %v", err)
+	}
+
+	// Second call: 5 more processed
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 5.0},
+		{"metric_name": "dropped", "ip_type": "ipv4", "origin": "crowdsec", "remediation_type": "ban", "val": 2.0},
+	})
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("second UpdateMetrics failed: %v", err)
+	}
+
+	processed := gaugeValue(metrics.TotalProcessedRequests.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if processed != 15.0 {
+		t.Errorf("processed = %f, want 15 (10+5)", processed)
+	}
+
+	dropped := gaugeValue(metrics.TotalBlockedRequests.With(prometheus.Labels{
+		"origin": "crowdsec", "remediation": "ban", "ip_type": "ipv4", "account": "test-account",
+	}))
+	if dropped != 5.0 {
+		t.Errorf("dropped = %f, want 5 (3+2)", dropped)
+	}
+}
+
+func TestUpdateMetrics_ConcurrentSafety(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 1.0},
+	})
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = m.UpdateMetrics()
+		}()
+	}
+	wg.Wait()
+
+	// Mutex serializes calls: each adds 1.0, total = 20.
+	// The -race flag validates no data races.
+	val := m.cumulativeMetrics["processed:ipv4:test-account"]
+	if val != float64(goroutines) {
+		t.Errorf("cumulative = %f, want %d", val, goroutines)
+	}
+}
+
+func TestUpdateMetrics_InvalidMetricName(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": 12345, "val": 1.0}, // metric_name is not a string
+	})
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("should not return error for bad metric_name type: %v", err)
+	}
+}
+
+func TestUpdateMetrics_InvalidVal(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "val": "not-a-number"},
+	})
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("should not return error for bad val type: %v", err)
+	}
+}
+
+func TestUpdateMetrics_UnknownMetric(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "unknown_metric", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 1.0},
+	})
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("unknown metric should not cause error: %v", err)
+	}
+}
+
+func TestUpdateMetrics_EmptyResult(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient(nil)
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("empty result should not cause error: %v", err)
+	}
+	if len(m.cumulativeMetrics) != 0 {
+		t.Errorf("cumulative should be empty, got %v", m.cumulativeMetrics)
+	}
+}
+
+func TestUpdateMetrics_QueryError(t *testing.T) {
+	m := newTestManager()
+	originalPoll := m.lastMetricsPoll
+	m.httpClient = makeAEErrorClient(500, "internal server error")
+
+	err := m.UpdateMetrics()
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !m.lastMetricsPoll.Equal(originalPoll) {
+		t.Error("lastMetricsPoll should not advance on error")
+	}
+}
+
+func TestUpdateMetrics_AdvancesTimestamp(t *testing.T) {
+	m := newTestManager()
+	before := time.Now().UTC()
+	m.lastMetricsPoll = before.Add(-5 * time.Minute)
+	m.httpClient = makeAEResponseClient(nil)
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !m.lastMetricsPoll.After(before.Add(-1 * time.Second)) {
+		t.Errorf("lastMetricsPoll should be ~now, got %v", m.lastMetricsPoll)
+	}
+}
+
+func TestUpdateMetrics_QueryContainsTimestamp(t *testing.T) {
+	emptyResp := `{"meta":[],"data":[],"rows":0}`
+	client, captured := captureRequestClient(emptyResp)
+
+	pollTime := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
+	m := newTestManager()
+	m.lastMetricsPoll = pollTime
+	m.httpClient = client
+
+	_ = m.UpdateMetrics()
+
+	if !strings.Contains(captured.Body, "2025-06-15 14:30:00") {
+		t.Errorf("query should contain formatted timestamp, got:\n%s", captured.Body)
+	}
+	if !strings.Contains(captured.Body, "FROM test_dataset") {
+		t.Errorf("query should contain dataset name, got:\n%s", captured.Body)
+	}
+	if !strings.Contains(captured.Body, "FORMAT JSON") {
+		t.Errorf("query should contain FORMAT JSON, got:\n%s", captured.Body)
+	}
+}
+
+func TestUpdateMetrics_EscapesSingleQuotes(t *testing.T) {
+	emptyResp := `{"meta":[],"data":[],"rows":0}`
+	client, captured := captureRequestClient(emptyResp)
+
+	m := newTestManager()
+	m.AccountCfg.Name = "Ray's Account"
+	m.httpClient = client
+
+	_ = m.UpdateMetrics()
+
+	if strings.Contains(captured.Body, "Ray's Account") {
+		t.Error("unescaped single quote found in SQL query")
+	}
+	if !strings.Contains(captured.Body, `Ray\'s Account`) {
+		t.Errorf("expected escaped single quote in query, got:\n%s", captured.Body)
+	}
+}
+
+// ============================================================
+// Group 3: cleanupLegacyD1Databases
+// ============================================================
+
+func TestCleanupLegacyD1_FindsAndDeletes(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return []cf.D1Database{
+				{UUID: "db-legacy", Name: "CROWDSECCFBOUNCERDB"},
+				{UUID: "db-other", Name: "unrelated-database"},
+			}, nil, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 1 {
+		t.Fatalf("expected 1 delete call, got %d", len(mock.deleteD1Calls))
+	}
+	if mock.deleteD1Calls[0] != "db-legacy" {
+		t.Errorf("deleted %q, want db-legacy", mock.deleteD1Calls[0])
+	}
+}
+
+func TestCleanupLegacyD1_NoneFound(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return []cf.D1Database{
+				{UUID: "db-other", Name: "unrelated-database"},
+			}, nil, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 0 {
+		t.Errorf("expected 0 delete calls, got %d", len(mock.deleteD1Calls))
+	}
+}
+
+func TestCleanupLegacyD1_ListError(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return nil, nil, errors.New("permission denied")
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	// Should not panic or propagate error
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 0 {
+		t.Error("should not attempt deletes after list error")
+	}
+}
+
+func TestCleanupLegacyD1_DeleteError(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return []cf.D1Database{
+				{UUID: "db-legacy", Name: "CROWDSECCFBOUNCERDB"},
+			}, nil, nil
+		},
+		deleteD1DatabaseFn: func(_ context.Context, _ *cf.ResourceContainer, _ string) error {
+			return errors.New("delete failed")
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	// Should warn but not panic
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 1 {
+		t.Error("should have attempted delete despite failure")
+	}
+}
+
+// ============================================================
+// Group 4: Manager Initialization
+// ============================================================
+
+func TestManagerInit_LastMetricsPollSet(t *testing.T) {
+	m := newTestManager()
+	if m.lastMetricsPoll.IsZero() {
+		t.Error("lastMetricsPoll should not be zero")
+	}
+	elapsed := time.Since(m.lastMetricsPoll)
+	if elapsed > 3*time.Minute || elapsed < 1*time.Minute {
+		t.Errorf("lastMetricsPoll should be ~2min ago, got %v ago", elapsed)
+	}
+}
+
+func TestManagerInit_CumulativeMetricsMap(t *testing.T) {
+	m := newTestManager()
+	if m.cumulativeMetrics == nil {
+		t.Error("cumulativeMetrics should not be nil")
+	}
+	if len(m.cumulativeMetrics) != 0 {
+		t.Errorf("cumulativeMetrics should be empty, got %v", m.cumulativeMetrics)
+	}
+}
+
+func TestManagerInit_HttpClientSet(t *testing.T) {
+	m := newTestManager()
+	if m.httpClient == nil {
+		t.Error("httpClient should not be nil")
+	}
+}
+
+// obsFromBody extracts the observability section from a JSON request body.
+func obsFromBody(t *testing.T, rawBody string) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal([]byte(rawBody), &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	obs, ok := body["observability"].(map[string]any)
+	if !ok {
+		t.Fatal("body missing observability key")
+	}
+	return obs
+}
+
+func tracesFromObs(t *testing.T, obs map[string]any) map[string]any {
+	t.Helper()
+	traces, ok := obs["traces"].(map[string]any)
+	if !ok {
+		t.Fatal("body missing observability.traces key")
+	}
+	return traces
+}
+
+// --- Group 5: enableWorkerObservability ---
+
+func TestEnableObservability_NilConfig_Skipped(t *testing.T) {
+	m := newTestManager()
+	// Transport that fails if any request is made
+	m.httpClient = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			t.Fatal("no HTTP request should be made when observability is nil")
+			return nil, errors.New("unreachable")
+		}),
+	}
+	m.Worker.Observability = nil
+
+	if err := m.enableWorkerObservability("test-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnableObservability_SendsCorrectRequest(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := true
+	rate := 1.0
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{
+		Enabled:          &enabled,
+		HeadSamplingRate: &rate,
+	}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured.Request.Method != http.MethodPatch {
+		t.Errorf("method = %s, want PATCH", captured.Request.Method)
+	}
+	wantURL := "https://api.cloudflare.com/client/v4/accounts/test-account-id/workers/scripts/my-worker/script-settings"
+	if captured.Request.URL.String() != wantURL {
+		t.Errorf("URL = %s, want %s", captured.Request.URL.String(), wantURL)
+	}
+	if captured.Request.Header.Get("Authorization") != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want %q", captured.Request.Header.Get("Authorization"), "Bearer test-token")
+	}
+	if captured.Request.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", captured.Request.Header.Get("Content-Type"))
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if enabled, ok := obs["enabled"].(bool); !ok || !enabled {
+		t.Errorf("enabled = %v, want true", obs["enabled"])
+	}
+	if obs["head_sampling_rate"] != 1.0 {
+		t.Errorf("head_sampling_rate = %v, want 1", obs["head_sampling_rate"])
+	}
+
+	traces := tracesFromObs(t, obs)
+	if enabled, ok := traces["enabled"].(bool); !ok || !enabled {
+		t.Errorf("traces.enabled = %v, want true", traces["enabled"])
+	}
+	if traces["head_sampling_rate"] != 1.0 {
+		t.Errorf("traces.head_sampling_rate = %v, want 1", traces["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_CustomSamplingRate(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := true
+	rate := 0.05
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{
+		Enabled:          &enabled,
+		HeadSamplingRate: &rate,
+	}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if obs["head_sampling_rate"] != 0.05 {
+		t.Errorf("head_sampling_rate = %v, want 0.05", obs["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_HTTPError(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = makeAEErrorClient(500, "internal server error")
+
+	enabled := true
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{Enabled: &enabled}
+
+	err := m.enableWorkerObservability("my-worker")
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should contain status code: %v", err)
+	}
+}
+
+func TestEnableObservability_DefaultValues(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	// Non-nil config but both fields nil — should default to enabled=true, rate=1.0
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if enabled, ok := obs["enabled"].(bool); !ok || !enabled {
+		t.Errorf("enabled = %v, want true (default)", obs["enabled"])
+	}
+	if obs["head_sampling_rate"] != 1.0 {
+		t.Errorf("head_sampling_rate = %v, want 1.0 (default)", obs["head_sampling_rate"])
+	}
+
+	// Traces should inherit top-level defaults
+	traces := tracesFromObs(t, obs)
+	if enabled, ok := traces["enabled"].(bool); !ok || !enabled {
+		t.Errorf("traces.enabled = %v, want true (default)", traces["enabled"])
+	}
+	if traces["head_sampling_rate"] != 1.0 {
+		t.Errorf("traces.head_sampling_rate = %v, want 1.0 (default)", traces["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_NetworkError(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		}),
+	}
+	enabled := true
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{Enabled: &enabled}
+
+	err := m.enableWorkerObservability("my-worker")
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+	if !strings.Contains(err.Error(), "observability settings request failed") {
+		t.Errorf("error should mention request failure: %v", err)
+	}
+}
+
+func TestEnableObservability_CustomTracesConfig(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := true
+	logRate := 1.0
+	traceRate := 0.1
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{
+		Enabled:          &enabled,
+		HeadSamplingRate: &logRate,
+		Traces: &cfg.WorkerTracesConfig{
+			Enabled:          &enabled,
+			HeadSamplingRate: &traceRate,
+		},
+	}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if obs["head_sampling_rate"] != 1.0 {
+		t.Errorf("log sampling rate = %v, want 1.0", obs["head_sampling_rate"])
+	}
+	traces := tracesFromObs(t, obs)
+	if traces["head_sampling_rate"] != 0.1 {
+		t.Errorf("trace sampling rate = %v, want 0.1", traces["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_ExplicitlyDisabled(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := false
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{Enabled: &enabled}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if enabled, ok := obs["enabled"].(bool); !ok || enabled {
+		t.Errorf("enabled = %v, want false", obs["enabled"])
+	}
+}

--- a/pkg/cloudflare/metrics.sql
+++ b/pkg/cloudflare/metrics.sql
@@ -1,8 +1,0 @@
-CREATE TABLE IF NOT EXISTS metrics (
-  val INTEGER DEFAULT 1,
-  metric_name TEXT,
-  origin TEXT NOT NULL DEFAULT '',
-  remediation_type TEXT NOT NULL DEFAULT '',
-  ip_type TEXT NOT NULL DEFAULT '',
-  UNIQUE(metric_name, origin, remediation_type, ip_type)
-);

--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7332,31 +7332,16 @@ const writeToKV = async (kv, key, value) => {
       return null;
     };
 
-    const incrementMetrics = async (
-      metricName,
-      ipType,
-      origin,
-      remediation_type,
-    ) => {
-      if (env.CROWDSECCFBOUNCERDB !== undefined) {
-        let parameters = [
-          metricName,
-          origin || "",
-          remediation_type || "",
-          ipType,
-        ];
-        let query = `
-          INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
-          VALUES (1, ?, ?, ?, ?)
-          ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
-        `;
-        try {
-          await env.CROWDSECCFBOUNCERDB.prepare(query)
-            .bind(...parameters)
-            .run();
-        } catch (error) {
-          console.error("Error incrementing metrics:", error);
-        }
+    const writeMetricEvent = (metricName, ipType, origin, remediationType) => {
+      if (!env.CROWDSECCFBOUNCER_AE) return;
+      try {
+        env.CROWDSECCFBOUNCER_AE.writeDataPoint({
+          indexes: [env.ACCOUNT_NAME || "default"],
+          blobs: [metricName, ipType, origin || "", remediationType || ""],
+          doubles: [1],
+        });
+      } catch (e) {
+        console.error("AE write failed:", e);
       }
     };
 
@@ -7366,7 +7351,7 @@ const writeToKV = async (kv, key, value) => {
     }
     const ipType = ipaddr.parse(clientIP).kind();
 
-    ctx.waitUntil(incrementMetrics("processed", ipType));
+    writeMetricEvent("processed", ipType);
 
     let remediation = await getRemediationForRequest(request, env);
     if (remediation === null) {
@@ -7388,10 +7373,10 @@ const writeToKV = async (kv, key, value) => {
     console.log("Remediation for request is " + remediation);
     switch (remediation) {
       case "ban":
-        ctx.waitUntil(incrementMetrics("dropped", ipType, "crowdsec", "ban"));
+        writeMetricEvent("dropped", ipType, "crowdsec", "ban");
         return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
       case "captcha":
-        ctx.waitUntil(incrementMetrics("dropped", ipType, "crowdsec", "captcha"));
+        writeMetricEvent("dropped", ipType, "crowdsec", "captcha");
         return env.LOG_ONLY === "true"
           ? fetch(request)
           : await doCaptcha(env, zoneForThisRequest);

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -276,31 +276,16 @@ export default {
       return null;
     };
 
-    const incrementMetrics = async (
-      metricName,
-      ipType,
-      origin,
-      remediation_type,
-    ) => {
-      if (env.CROWDSECCFBOUNCERDB !== undefined) {
-        let parameters = [
-          metricName,
-          origin || "",
-          remediation_type || "",
-          ipType,
-        ];
-        let query = `
-          INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
-          VALUES (1, ?, ?, ?, ?)
-          ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
-        `;
-        try {
-          await env.CROWDSECCFBOUNCERDB.prepare(query)
-            .bind(...parameters)
-            .run();
-        } catch (error) {
-          console.error("Error incrementing metrics:", error);
-        }
+    const writeMetricEvent = (metricName, ipType, origin, remediationType) => {
+      if (!env.CROWDSECCFBOUNCER_AE) return;
+      try {
+        env.CROWDSECCFBOUNCER_AE.writeDataPoint({
+          indexes: [env.ACCOUNT_NAME || "default"],
+          blobs: [metricName, ipType, origin || "", remediationType || ""],
+          doubles: [1],
+        });
+      } catch (e) {
+        console.error("AE write failed:", e);
       }
     };
 
@@ -310,7 +295,7 @@ export default {
     }
     const ipType = ipaddr.parse(clientIP).kind();
 
-    ctx.waitUntil(incrementMetrics("processed", ipType));
+    writeMetricEvent("processed", ipType);
 
     let remediation = await getRemediationForRequest(request, env);
     if (remediation === null) {
@@ -332,10 +317,10 @@ export default {
     console.log("Remediation for request is " + remediation);
     switch (remediation) {
       case "ban":
-        ctx.waitUntil(incrementMetrics("dropped", ipType, "crowdsec", "ban"));
+        writeMetricEvent("dropped", ipType, "crowdsec", "ban");
         return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
       case "captcha":
-        ctx.waitUntil(incrementMetrics("dropped", ipType, "crowdsec", "captcha"));
+        writeMetricEvent("dropped", ipType, "crowdsec", "captcha");
         return env.LOG_ONLY === "true"
           ? fetch(request)
           : await doCaptcha(env, zoneForThisRequest);


### PR DESCRIPTION
## Summary

Replace Cloudflare D1 with Workers Analytics Engine (AE) for metrics collection, and add native Workers Observability (logs + traces) configuration on deploy.

### What changed

- **D1 → Analytics Engine**: All metrics (blocked requests, processed requests, active decisions) are now written to AE via the worker's `writeDataPoint()` API and queried via the AE SQL API. The D1 database, schema file (`metrics.sql`), and all D1-related bindings/code are removed.
- **Workers Observability**: New opt-in `observability` config block enables native CF Workers logging and tracing on deploy. Configures via `PATCH /accounts/{id}/workers/scripts/{name}/script-settings` since `cloudflare-go` SDK doesn't expose this yet. Traces inherit top-level settings by default, can be independently overridden.
- **Worker JS**: Updated to use `writeDataPoint()` with structured blobs/doubles instead of D1 SQL inserts. Metrics are append-only — no more read-modify-write race conditions.
- **Metrics query**: `queryAnalyticsEngine` uses raw SQL via `text/plain` Content-Type (AE SQL API requirement), with proper single-quote escaping and cumulative counter tracking via `.Set()`.
- **Test coverage**: 39 new tests across `pkg/cloudflare/` and `pkg/cfg/` covering AE query construction, HTTP interactions, config parsing, observability, and edge cases. All pass with `-race`.
- **Config**: New fields `analytics_dataset` (defaults to `crowdsec_cloudflare_bouncer`) and `observability` block. Both are opt-in with sensible defaults — zero breaking changes to existing configs.

### Upstream issues addressed

| Issue | Title | How |
|-------|-------|-----|
| [#68](https://github.com/crowdsecurity/cs-cloudflare-worker-bouncer/issues/68) | D1 hard failure on metrics | **Resolved** — D1 completely removed; AE is append-only and doesn't block the request path |
| [#80](https://github.com/crowdsecurity/cs-cloudflare-worker-bouncer/issues/80) | Error 1101 from D1/KV runtime | **Resolved** — D1 runtime errors eliminated by removing D1 entirely |

Issues **not addressed** by this PR (unrelated to metrics/observability):
- #77 (KV rate limit on deploy), #81 (decisions silently dropped by stream), #67 (worker recreated on container restart), #66 (ACTIONS_BY_DOMAIN >5KB), #65 (context canceled during backoff)

### Config example

```yaml
cloudflare_config:
  worker:
    analytics_dataset: crowdsec_cloudflare_bouncer  # default
    observability:
      enabled: true
      head_sampling_rate: 1
      traces:
        enabled: true
        head_sampling_rate: 0.1  # independent trace sampling
```

## Test plan

- [x] `go test -v -race ./pkg/cloudflare/ ./pkg/cfg/` — 39/39 pass
- [x] `go vet ./...` — clean
- [x] Config parsing: nil observability by default, full YAML round-trip, invalid sampling rate rejected
- [x] AE query: correct SQL generation, Content-Type, escaping, HTTP error handling
- [x] Observability: nil skip, correct PATCH payload (logs + traces), custom rates, disabled state, network errors
- [ ] Deploy to staging and verify AE metrics in CF dashboard
- [ ] Verify Workers Observability logs + traces visible in CF dashboard