### PR TITLE
fix(metrics): close SQL injection and two AE polling correctness gaps

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,16 +138,12 @@ func (m *metricsHandler) metricsUpdater(met *models.RemediationComponentsMetrics
 	}
 }
 
-func (m *metricsHandler) computeMetricsHandler(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, manager := range m.cfManagers {
-			err := manager.UpdateMetrics()
-			if err != nil {
-				log.Errorf("unable to update metrics for account %s: %s", manager.AccountCfg.Name, err)
-			}
-		}
-		next.ServeHTTP(w, r)
-	})
+// computeMetricsHandler is a pass-through. UpdateMetrics is driven solely by
+// metricsUpdater on the csbouncer push schedule; polling AE from the scrape
+// path too would give two callers one shared lastMetricsPoll cursor and couple
+// scrape latency to AE API latency.
+func (*metricsHandler) computeMetricsHandler(next http.Handler) http.Handler {
+	return next
 }
 
 func cleanUp(managers []*cf.CloudflareAccountManager, c context.CancelFunc, ctx context.Context) {

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -20,6 +21,14 @@ import (
 var (
 	VarNameForActionsByDomain = "ACTIONS_BY_DOMAIN"
 	ErrEmptyConfig            = errors.New("empty config")
+)
+
+// validAccountName / validAnalyticsDataset enforce that values interpolated into
+// the AE SQL query cannot break out of a ClickHouse string literal or identifier
+// context. Rejecting at config load eliminates the need for runtime escaping.
+var (
+	validAccountName      = regexp.MustCompile(`^[\p{L}\p{N} ._\-()&+@:,]*$`)
+	validAnalyticsDataset = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`)
 )
 
 // KVWorkerBindingName and AEWorkerBindingName are the worker env binding names hardcoded in the
@@ -198,7 +207,8 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 	validAction := map[string]bool{"captcha": true, "ban": true}
 	validChoiceMsg := "valid choices are either of 'ban', 'captcha'"
 
-	for _, account := range config.CloudflareConfig.Accounts {
+	for i := range config.CloudflareConfig.Accounts {
+		account := &config.CloudflareConfig.Accounts[i]
 		if _, ok := accountIDSet[account.ID]; ok {
 			return nil, fmt.Errorf("the account '%s' is duplicated", account.ID)
 		}
@@ -206,6 +216,15 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 
 		if account.Token == "" {
 			return nil, fmt.Errorf("the account '%s' is missing token", account.ID)
+		}
+
+		// Mirror the worker's `env.ACCOUNT_NAME || "default"` fallback: an empty
+		// name would query `index1 = ''` and never match what the worker writes.
+		if account.Name == "" {
+			account.Name = "default"
+		}
+		if !validAccountName.MatchString(account.Name) {
+			return nil, fmt.Errorf("account '%s' has invalid account_name %q: permitted characters are letters, digits, spaces, and . _ - ( ) & + @ : ,", account.ID, account.Name)
 		}
 
 		for _, zone := range account.ZoneConfigs {
@@ -230,6 +249,10 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 		}
 	}
 	config.CloudflareConfig.Worker.setDefaults() // set defaults for worker
+
+	if !validAnalyticsDataset.MatchString(config.CloudflareConfig.Worker.AnalyticsDataset) {
+		return nil, fmt.Errorf("invalid analytics_dataset %q: must match %s", config.CloudflareConfig.Worker.AnalyticsDataset, validAnalyticsDataset.String())
+	}
 
 	if obs := config.CloudflareConfig.Worker.Observability; obs != nil {
 		if r := obs.HeadSamplingRate; r != nil && (*r < 0 || *r > 1) {
@@ -322,9 +345,19 @@ func ConfigTokens(tokens string, baseConfigPath string) (string, error) {
 		for _, account := range accounts {
 			accountByID[account.ID] = account
 			if _, ok := accountIDXByID[account.ID]; !ok {
+				// The Cloudflare-supplied account name flows into the AE SQL
+				// query, so it must satisfy validAccountName. A name that
+				// doesn't (e.g. "O'Brien") would generate a config that
+				// NewConfig rejects on the next startup — fall back to the
+				// account ID, which is always a safe identifier.
+				name := strings.Replace(account.Name, "'s Account", "", -1)
+				if !validAccountName.MatchString(name) {
+					log.Warnf("Cloudflare account name %q contains unsupported characters; using account ID %q as account_name", account.Name, account.ID)
+					name = account.ID
+				}
 				accountConfigs = append(accountConfigs, AccountConfig{
 					ID:          account.ID,
-					Name:        strings.Replace(account.Name, "'s Account", "", -1),
+					Name:        name,
 					ZoneConfigs: make([]*ZoneConfig, 0),
 					Token:       token,
 					BanTemplate: "",

--- a/pkg/cfg/config_test.go
+++ b/pkg/cfg/config_test.go
@@ -74,7 +74,7 @@ func TestCreateWorkerParams_AEBinding(t *testing.T) {
 func TestCreateWorkerParams_AccountNameBinding(t *testing.T) {
 	w := &cfg.CloudflareWorkerCreateParams{}
 
-	params := w.CreateWorkerParams("script", "kv-ns-id", []byte(`{}`), "Ray's Account")
+	params := w.CreateWorkerParams("script", "kv-ns-id", []byte(`{}`), "Acme Corp")
 
 	binding, ok := params.Bindings["ACCOUNT_NAME"]
 	if !ok {
@@ -86,8 +86,8 @@ func TestCreateWorkerParams_AccountNameBinding(t *testing.T) {
 		t.Fatalf("ACCOUNT_NAME binding is %T, want WorkerPlainTextBinding", binding)
 	}
 
-	if ptBinding.Text != "Ray's Account" {
-		t.Fatalf("ACCOUNT_NAME = %q, want %q", ptBinding.Text, "Ray's Account")
+	if ptBinding.Text != "Acme Corp" {
+		t.Fatalf("ACCOUNT_NAME = %q, want %q", ptBinding.Text, "Acme Corp")
 	}
 }
 
@@ -223,5 +223,85 @@ cloudflare_config:
 	}
 	if !strings.Contains(err.Error(), "head_sampling_rate must be between 0 and 1") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// configWith builds a minimal valid bouncer config. A non-empty accountName is
+// injected as account_name; a non-empty dataset as worker.analytics_dataset.
+func configWith(accountName, dataset string) []byte {
+	worker := ""
+	if dataset != "" {
+		worker = "  worker:\n    analytics_dataset: \"" + dataset + "\"\n"
+	}
+	name := ""
+	if accountName != "" {
+		name = "      account_name: \"" + accountName + "\"\n"
+	}
+	return []byte("\n" +
+		"crowdsec_config:\n" +
+		"  lapi_url: http://localhost:8080/\n" +
+		"  lapi_key: test-key\n" +
+		"  update_frequency: 10s\n" +
+		"cloudflare_config:\n" +
+		worker +
+		"  accounts:\n" +
+		"    - id: acc1\n" +
+		"      token: tok1\n" +
+		name +
+		"      zones:\n" +
+		"        - zone_id: zone1\n" +
+		"          actions: [\"ban\"]\n" +
+		"          default_action: ban\n" +
+		"          routes_to_protect: [\"*example.com/*\"]\n")
+}
+
+func TestAccountName_RejectsInjectionCharacters(t *testing.T) {
+	// Each payload carries a character that can break out of the AE SQL string
+	// literal ( ' or \ ); validation must reject all of them at config load.
+	cases := map[string]string{
+		"single quote": `O'Brien`,
+		"backslash":    `foo\\bar`,
+		"injection":    `foo'; DROP TABLE users; --`,
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := cfg.NewConfig(bytes.NewReader(configWith(payload, "")))
+			if err == nil || !strings.Contains(err.Error(), "invalid account_name") {
+				t.Fatalf("expected 'invalid account_name' rejection for %q, got: %v", payload, err)
+			}
+		})
+	}
+}
+
+func TestAccountName_AcceptsRealisticNames(t *testing.T) {
+	for _, name := range []string{"acme-prod", "Acme Corp", "Internal & External (prod)", "Acme + Co.", "owner@example.com"} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := cfg.NewConfig(bytes.NewReader(configWith(name, ""))); err != nil {
+				t.Errorf("NewConfig rejected valid name %q: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestAccountName_EmptyDefaultsToDefault(t *testing.T) {
+	// An omitted account_name must become "default" so the AE query's
+	// index1 filter matches the worker's `env.ACCOUNT_NAME || "default"`.
+	c, err := cfg.NewConfig(bytes.NewReader(configWith("", "")))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	if got := c.CloudflareConfig.Accounts[0].Name; got != "default" {
+		t.Errorf("empty account_name = %q, want \"default\"", got)
+	}
+}
+
+func TestAnalyticsDataset_RejectsInvalidIdentifiers(t *testing.T) {
+	for _, ds := range []string{"foo-bar", "foo bar", "1starts-with-digit", "foo;DROP", "foo'bar"} {
+		t.Run(ds, func(t *testing.T) {
+			_, err := cfg.NewConfig(bytes.NewReader(configWith("", ds)))
+			if err == nil || !strings.Contains(err.Error(), "invalid analytics_dataset") {
+				t.Fatalf("expected 'invalid analytics_dataset' rejection for %q, got: %v", ds, err)
+			}
+		})
 	}
 }

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -947,13 +947,16 @@ func (m *CloudflareAccountManager) UpdateMetrics() error {
 	defer m.metricsMu.Unlock()
 
 	m.logger.Debug("Getting metrics from Analytics Engine")
-	now := time.Now().UTC()
 
-	// Escape single quotes to prevent query breakage (e.g. "Ray's Account")
-	safeName := strings.ReplaceAll(m.AccountCfg.Name, "'", "\\'")
+	// AE only supports second-precision toDateTime. Query the half-open window
+	// [lastMetricsPoll, windowEnd) and advance the cursor to windowEnd so every
+	// second is counted exactly once. windowEnd excludes the in-progress second
+	// so events still arriving in it aren't undercounted — they land next poll.
+	windowEnd := time.Now().UTC().Truncate(time.Second)
 
 	// AE blob field mapping (must match writeMetricEvent in worker.js):
 	//   blob1 = metric_name, blob2 = ip_type, blob3 = origin, blob4 = remediation_type
+	// AnalyticsDataset and AccountCfg.Name are allowlist-validated at config load.
 	query := fmt.Sprintf(`SELECT
 		blob1 AS metric_name,
 		blob2 AS ip_type,
@@ -961,20 +964,22 @@ func (m *CloudflareAccountManager) UpdateMetrics() error {
 		blob4 AS remediation_type,
 		SUM(_sample_interval * double1) AS val
 	FROM %s
-	WHERE timestamp > toDateTime('%s')
+	WHERE timestamp >= toDateTime('%s')
+		AND timestamp < toDateTime('%s')
 		AND index1 = '%s'
 	GROUP BY metric_name, ip_type, origin, remediation_type
 	FORMAT JSON`,
 		m.Worker.AnalyticsDataset,
 		m.lastMetricsPoll.Format("2006-01-02 15:04:05"),
-		safeName,
+		windowEnd.Format("2006-01-02 15:04:05"),
+		m.AccountCfg.Name,
 	)
 
 	result, err := m.queryAnalyticsEngine(query)
 	if err != nil {
 		return fmt.Errorf("unable to query Analytics Engine: %w", err)
 	}
-	m.lastMetricsPoll = now
+	m.lastMetricsPoll = windowEnd
 	m.logger.Tracef("AE result: %+v", result)
 
 	for _, row := range result.Data {

--- a/pkg/cloudflare/cloudflare_test.go
+++ b/pkg/cloudflare/cloudflare_test.go
@@ -454,15 +454,20 @@ func TestUpdateMetrics_QueryContainsTimestamp(t *testing.T) {
 	emptyResp := `{"meta":[],"data":[],"rows":0}`
 	client, captured := captureRequestClient(emptyResp)
 
-	pollTime := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
+	// AE supports only second-precision toDateTime; the sub-second component
+	// of lastMetricsPoll is truncated in the lower bound.
+	pollTime := time.Date(2025, 6, 15, 14, 30, 0, 123000000, time.UTC)
 	m := newTestManager()
 	m.lastMetricsPoll = pollTime
 	m.httpClient = client
 
 	_ = m.UpdateMetrics()
 
-	if !strings.Contains(captured.Body, "2025-06-15 14:30:00") {
-		t.Errorf("query should contain formatted timestamp, got:\n%s", captured.Body)
+	if !strings.Contains(captured.Body, "timestamp >= toDateTime('2025-06-15 14:30:00')") {
+		t.Errorf("query should contain second-precision lower bound, got:\n%s", captured.Body)
+	}
+	if !strings.Contains(captured.Body, "timestamp < toDateTime(") {
+		t.Errorf("query should contain an upper window bound, got:\n%s", captured.Body)
 	}
 	if !strings.Contains(captured.Body, "FROM test_dataset") {
 		t.Errorf("query should contain dataset name, got:\n%s", captured.Body)
@@ -472,21 +477,25 @@ func TestUpdateMetrics_QueryContainsTimestamp(t *testing.T) {
 	}
 }
 
-func TestUpdateMetrics_EscapesSingleQuotes(t *testing.T) {
+func TestUpdateMetrics_QueryInterpolation_NoEscaping(t *testing.T) {
+	// Account name is allowlist-validated at config load (see pkg/cfg). The
+	// runtime query interpolates it directly without escaping; if a name
+	// containing a single quote ever reached this code path it would terminate
+	// the string literal and break the query, which is the failure we want.
 	emptyResp := `{"meta":[],"data":[],"rows":0}`
 	client, captured := captureRequestClient(emptyResp)
 
 	m := newTestManager()
-	m.AccountCfg.Name = "Ray's Account"
+	m.AccountCfg.Name = "acme-prod"
 	m.httpClient = client
 
 	_ = m.UpdateMetrics()
 
-	if strings.Contains(captured.Body, "Ray's Account") {
-		t.Error("unescaped single quote found in SQL query")
+	if !strings.Contains(captured.Body, "index1 = 'acme-prod'") {
+		t.Errorf("expected literal account name in WHERE clause, got:\n%s", captured.Body)
 	}
-	if !strings.Contains(captured.Body, `Ray\'s Account`) {
-		t.Errorf("expected escaped single quote in query, got:\n%s", captured.Body)
+	if strings.Contains(captured.Body, `\'`) {
+		t.Errorf("query should not contain backslash escapes (validation guarantees safe names), got:\n%s", captured.Body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three correctness defects in the Analytics Engine metrics path, found in review of the post-D1-migration code.

**SQL injection via account name.** The previous defence escaped only single quotes (`\'`), which ClickHouse re-parses as escape-then-quote — a crafted `account_name` could break out of the AE query's `WHERE` clause and read across the shared dataset. Fix: allowlist-validate `account_name` and `analytics_dataset` at config load and drop the runtime escape entirely. Empty `account_name` now defaults to `"default"` so the query's `index1` filter matches the worker's `env.ACCOUNT_NAME || "default"` fallback, and the `-g` token-setup flow validates Cloudflare-supplied names (falling back to the account ID) so it can't emit a config that fails to load on the next startup.

**Window-boundary events dropped.** `lastMetricsPoll` was second-precision while events land mid-second, so events at the polling instant fell into the exclusive `>` gap and were never counted. Fix: query a half-open whole-second window `[lastMetricsPoll, windowEnd)` with `>=` / `<` and advance the cursor to `windowEnd`, counting every second exactly once. `windowEnd` excludes the in-progress second to avoid undercount. (AE has no sub-second `toDateTime64`; second precision is the available primitive.)

**Dual `UpdateMetrics` callers.** `computeMetricsHandler` ran an AE query on every `/metrics` scrape *in addition to* the csbouncer push schedule, giving two callers one shared cursor and coupling scrape latency to AE API latency. The scrape path is now a pass-through; `metricsUpdater` owns the polling cadence.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/cfg/ ./pkg/cloudflare/` — new tests cover injection-character rejection, realistic-name acceptance, empty-name defaulting, dataset validation, and the windowed query shape
- [x] `golangci-lint run` — clean
- [ ] Smoke-test the windowed query against the live AE SQL API before relying on it — unit tests use mock HTTP clients and cannot confirm AE accepts the exact query

## Follow-up

`feat/worker-latency-tracking` will be rebased onto this branch (not merged independently — it still carries the old escape code) and has two known issues to fix before it lands: `processed` undercounting blocked requests, and `error`-metric log spam.