### PR TITLE
feat(metrics): record request latency and worker exceptions in AE

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -386,7 +386,8 @@ func Execute(opts ExecuteOptions) error {
 	})
 
 	prometheus.MustRegister(csbouncer.TotalLAPICalls, csbouncer.TotalLAPIError, metrics.CloudflareAPICallsByAccount, metrics.TotalKeysByAccount,
-		metrics.TotalActiveDecisions, metrics.TotalBlockedRequests, metrics.TotalProcessedRequests)
+		metrics.TotalActiveDecisions, metrics.TotalBlockedRequests, metrics.TotalProcessedRequests, metrics.AverageLatencyMs,
+		metrics.TotalErrors)
 	if conf.PrometheusConfig.Enabled {
 		g.Go(func() error {
 			http.Handle("/metrics", mHandler.computeMetricsHandler(promhttp.Handler()))

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -954,15 +954,17 @@ func (m *CloudflareAccountManager) UpdateMetrics() error {
 	// so events still arriving in it aren't undercounted — they land next poll.
 	windowEnd := time.Now().UTC().Truncate(time.Second)
 
-	// AE blob field mapping (must match writeMetricEvent in worker.js):
+	// AE field mapping (must match writeMetricEvent in worker.js):
 	//   blob1 = metric_name, blob2 = ip_type, blob3 = origin, blob4 = remediation_type
+	//   double1 = count (1), double2 = latency_ms
 	// AnalyticsDataset and AccountCfg.Name are allowlist-validated at config load.
 	query := fmt.Sprintf(`SELECT
 		blob1 AS metric_name,
 		blob2 AS ip_type,
 		blob3 AS origin,
 		blob4 AS remediation_type,
-		SUM(_sample_interval * double1) AS val
+		SUM(_sample_interval * double1) AS val,
+		AVG(double2) AS avg_latency_ms
 	FROM %s
 	WHERE timestamp >= toDateTime('%s')
 		AND timestamp < toDateTime('%s')
@@ -1018,8 +1020,23 @@ func (m *CloudflareAccountManager) UpdateMetrics() error {
 				"origin": origin, "remediation": remediation,
 				"ip_type": ipType, "account": m.AccountCfg.Name,
 			}).Set(m.cumulativeMetrics[key])
+		case "error":
+			key := "error:" + ipType + ":" + m.AccountCfg.Name
+			m.cumulativeMetrics[key] += val
+			metrics.TotalErrors.With(prometheus.Labels{
+				"ip_type": ipType, "account": m.AccountCfg.Name,
+			}).Set(m.cumulativeMetrics[key])
 		default:
 			m.logger.Warnf("Unknown metric from AE: %s", metricName)
+		}
+
+		if latency, ok := row["avg_latency_ms"].(float64); ok {
+			metrics.AverageLatencyMs.With(prometheus.Labels{
+				"account":     m.AccountCfg.Name,
+				"metric_name": metricName,
+				"ip_type":     ipType,
+				"remediation": remediation,
+			}).Set(latency)
 		}
 	}
 

--- a/pkg/cloudflare/cloudflare_test.go
+++ b/pkg/cloudflare/cloudflare_test.go
@@ -109,6 +109,8 @@ func newTestManager() *CloudflareAccountManager {
 func resetMetrics() {
 	metrics.TotalProcessedRequests.Reset()
 	metrics.TotalBlockedRequests.Reset()
+	metrics.AverageLatencyMs.Reset()
+	metrics.TotalErrors.Reset()
 }
 
 // --- Mock cloudflareAPI ---
@@ -282,8 +284,8 @@ func TestUpdateMetrics_HappyPath(t *testing.T) {
 	resetMetrics()
 	m := newTestManager()
 	m.httpClient = makeAEResponseClient([]map[string]any{
-		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 100.0},
-		{"metric_name": "dropped", "ip_type": "ipv6", "origin": "crowdsec", "remediation_type": "ban", "val": 7.0},
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 100.0, "avg_latency_ms": 12.5},
+		{"metric_name": "dropped", "ip_type": "ipv6", "origin": "crowdsec", "remediation_type": "ban", "val": 7.0, "avg_latency_ms": 45.0},
 	})
 
 	if err := m.UpdateMetrics(); err != nil {
@@ -302,6 +304,20 @@ func TestUpdateMetrics_HappyPath(t *testing.T) {
 	}))
 	if dropped != 7.0 {
 		t.Errorf("dropped = %f, want 7", dropped)
+	}
+
+	// Each grouped row gets its own label series — no last-row-wins.
+	processedLatency := gaugeValue(metrics.AverageLatencyMs.With(prometheus.Labels{
+		"account": "test-account", "metric_name": "processed", "ip_type": "ipv4", "remediation": "",
+	}))
+	if processedLatency != 12.5 {
+		t.Errorf("processed avg_latency_ms = %f, want 12.5", processedLatency)
+	}
+	droppedLatency := gaugeValue(metrics.AverageLatencyMs.With(prometheus.Labels{
+		"account": "test-account", "metric_name": "dropped", "ip_type": "ipv6", "remediation": "ban",
+	}))
+	if droppedLatency != 45.0 {
+		t.Errorf("dropped avg_latency_ms = %f, want 45", droppedLatency)
 	}
 }
 
@@ -407,6 +423,25 @@ func TestUpdateMetrics_UnknownMetric(t *testing.T) {
 	}
 }
 
+func TestUpdateMetrics_ErrorMetric(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "error", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 3.0},
+	})
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("UpdateMetrics failed: %v", err)
+	}
+
+	errs := gaugeValue(metrics.TotalErrors.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if errs != 3.0 {
+		t.Errorf("errors = %f, want 3", errs)
+	}
+}
+
 func TestUpdateMetrics_EmptyResult(t *testing.T) {
 	resetMetrics()
 	m := newTestManager()
@@ -475,6 +510,9 @@ func TestUpdateMetrics_QueryContainsTimestamp(t *testing.T) {
 	if !strings.Contains(captured.Body, "FORMAT JSON") {
 		t.Errorf("query should contain FORMAT JSON, got:\n%s", captured.Body)
 	}
+	if !strings.Contains(captured.Body, "AVG(double2) AS avg_latency_ms") {
+		t.Errorf("query should contain latency aggregation, got:\n%s", captured.Body)
+	}
 }
 
 func TestUpdateMetrics_QueryInterpolation_NoEscaping(t *testing.T) {
@@ -496,6 +534,26 @@ func TestUpdateMetrics_QueryInterpolation_NoEscaping(t *testing.T) {
 	}
 	if strings.Contains(captured.Body, `\'`) {
 		t.Errorf("query should not contain backslash escapes (validation guarantees safe names), got:\n%s", captured.Body)
+	}
+}
+
+func TestUpdateMetrics_MissingLatency_NoError(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	// AE row missing the avg_latency_ms field — defensive against partial responses.
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 5.0},
+	})
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("UpdateMetrics failed: %v", err)
+	}
+
+	processed := gaugeValue(metrics.TotalProcessedRequests.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if processed != 5.0 {
+		t.Errorf("processed = %f, want 5", processed)
 	}
 }
 

--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7332,13 +7332,13 @@ const writeToKV = async (kv, key, value) => {
       return null;
     };
 
-    const writeMetricEvent = (metricName, ipType, origin, remediationType) => {
+    const writeMetricEvent = (metricName, ipType, origin, remediationType, latencyMs) => {
       if (!env.CROWDSECCFBOUNCER_AE) return;
       try {
         env.CROWDSECCFBOUNCER_AE.writeDataPoint({
           indexes: [env.ACCOUNT_NAME || "default"],
           blobs: [metricName, ipType, origin || "", remediationType || ""],
-          doubles: [1],
+          doubles: [1, latencyMs || 0],
         });
       } catch (e) {
         console.error("AE write failed:", e);
@@ -7351,37 +7351,66 @@ const writeToKV = async (kv, key, value) => {
     }
     const ipType = ipaddr.parse(clientIP).kind();
 
-    writeMetricEvent("processed", ipType);
+    const start = Date.now();
+    let origin = "";
+    let remediationType = "";
+    let blocked = false;
+    let errored = false;
+    let response;
 
-    let remediation = await getRemediationForRequest(request, env);
-    if (remediation === null) {
-      console.log("No remediation found for request");
-      return fetch(request);
-    }
-    if (typeof env.ACTIONS_BY_DOMAIN === "string") {
-      env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
-    }
-    const zoneForThisRequest = getZoneFromReqURL(
-      request.url,
-      env.ACTIONS_BY_DOMAIN,
-    );
-    console.log("Zone for this request is " + zoneForThisRequest);
-    remediation = getSupportedActionForZone(
-      remediation,
-      env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
-    );
-    console.log("Remediation for request is " + remediation);
-    switch (remediation) {
-      case "ban":
-        writeMetricEvent("dropped", ipType, "crowdsec", "ban");
-        return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
-      case "captcha":
-        writeMetricEvent("dropped", ipType, "crowdsec", "captcha");
-        return env.LOG_ONLY === "true"
-          ? fetch(request)
-          : await doCaptcha(env, zoneForThisRequest);
-      default:
-        return fetch(request);
+    try {
+      let remediation = await getRemediationForRequest(request, env);
+      if (remediation === null) {
+        console.log("No remediation found for request");
+        response = await fetch(request);
+      } else {
+        if (typeof env.ACTIONS_BY_DOMAIN === "string") {
+          env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
+        }
+        const zoneForThisRequest = getZoneFromReqURL(
+          request.url,
+          env.ACTIONS_BY_DOMAIN,
+        );
+        console.log("Zone for this request is " + zoneForThisRequest);
+        remediation = getSupportedActionForZone(
+          remediation,
+          env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
+        );
+        console.log("Remediation for request is " + remediation);
+        switch (remediation) {
+          case "ban":
+            blocked = true;
+            origin = "crowdsec";
+            remediationType = "ban";
+            response = env.LOG_ONLY === "true" ? await fetch(request) : await doBan();
+            break;
+          case "captcha":
+            blocked = true;
+            origin = "crowdsec";
+            remediationType = "captcha";
+            response = env.LOG_ONLY === "true"
+              ? await fetch(request)
+              : await doCaptcha(env, zoneForThisRequest);
+            break;
+          default:
+            response = await fetch(request);
+        }
+      }
+      return response;
+    } catch (e) {
+      errored = true;
+      console.error("Worker handler exception:", e);
+      throw e;
+    } finally {
+      // Every request reaching here was processed; "dropped" and "error" are
+      // additional outcome tags so block-rate stays dropped/processed.
+      const latencyMs = Date.now() - start;
+      writeMetricEvent("processed", ipType, "", "", latencyMs);
+      if (errored) {
+        writeMetricEvent("error", ipType, "", "", latencyMs);
+      } else if (blocked) {
+        writeMetricEvent("dropped", ipType, origin, remediationType, latencyMs);
+      }
     }
   },
 });

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -276,13 +276,13 @@ export default {
       return null;
     };
 
-    const writeMetricEvent = (metricName, ipType, origin, remediationType) => {
+    const writeMetricEvent = (metricName, ipType, origin, remediationType, latencyMs) => {
       if (!env.CROWDSECCFBOUNCER_AE) return;
       try {
         env.CROWDSECCFBOUNCER_AE.writeDataPoint({
           indexes: [env.ACCOUNT_NAME || "default"],
           blobs: [metricName, ipType, origin || "", remediationType || ""],
-          doubles: [1],
+          doubles: [1, latencyMs || 0],
         });
       } catch (e) {
         console.error("AE write failed:", e);
@@ -295,37 +295,66 @@ export default {
     }
     const ipType = ipaddr.parse(clientIP).kind();
 
-    writeMetricEvent("processed", ipType);
+    const start = Date.now();
+    let origin = "";
+    let remediationType = "";
+    let blocked = false;
+    let errored = false;
+    let response;
 
-    let remediation = await getRemediationForRequest(request, env);
-    if (remediation === null) {
-      console.log("No remediation found for request");
-      return fetch(request);
-    }
-    if (typeof env.ACTIONS_BY_DOMAIN === "string") {
-      env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
-    }
-    const zoneForThisRequest = getZoneFromReqURL(
-      request.url,
-      env.ACTIONS_BY_DOMAIN,
-    );
-    console.log("Zone for this request is " + zoneForThisRequest);
-    remediation = getSupportedActionForZone(
-      remediation,
-      env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
-    );
-    console.log("Remediation for request is " + remediation);
-    switch (remediation) {
-      case "ban":
-        writeMetricEvent("dropped", ipType, "crowdsec", "ban");
-        return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
-      case "captcha":
-        writeMetricEvent("dropped", ipType, "crowdsec", "captcha");
-        return env.LOG_ONLY === "true"
-          ? fetch(request)
-          : await doCaptcha(env, zoneForThisRequest);
-      default:
-        return fetch(request);
+    try {
+      let remediation = await getRemediationForRequest(request, env);
+      if (remediation === null) {
+        console.log("No remediation found for request");
+        response = await fetch(request);
+      } else {
+        if (typeof env.ACTIONS_BY_DOMAIN === "string") {
+          env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
+        }
+        const zoneForThisRequest = getZoneFromReqURL(
+          request.url,
+          env.ACTIONS_BY_DOMAIN,
+        );
+        console.log("Zone for this request is " + zoneForThisRequest);
+        remediation = getSupportedActionForZone(
+          remediation,
+          env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
+        );
+        console.log("Remediation for request is " + remediation);
+        switch (remediation) {
+          case "ban":
+            blocked = true;
+            origin = "crowdsec";
+            remediationType = "ban";
+            response = env.LOG_ONLY === "true" ? await fetch(request) : await doBan();
+            break;
+          case "captcha":
+            blocked = true;
+            origin = "crowdsec";
+            remediationType = "captcha";
+            response = env.LOG_ONLY === "true"
+              ? await fetch(request)
+              : await doCaptcha(env, zoneForThisRequest);
+            break;
+          default:
+            response = await fetch(request);
+        }
+      }
+      return response;
+    } catch (e) {
+      errored = true;
+      console.error("Worker handler exception:", e);
+      throw e;
+    } finally {
+      // Every request reaching here was processed; "dropped" and "error" are
+      // additional outcome tags so block-rate stays dropped/processed.
+      const latencyMs = Date.now() - start;
+      writeMetricEvent("processed", ipType, "", "", latencyMs);
+      if (errored) {
+        writeMetricEvent("error", ipType, "", "", latencyMs);
+      } else if (blocked) {
+        writeMetricEvent("dropped", ipType, origin, remediationType, latencyMs);
+      }
     }
   },
 };

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,3 +40,13 @@ var TotalActiveDecisions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: ActiveDecisionsMetricName,
 	Help: "Total number of active decisions",
 }, []string{"origin", "ip_type", "scope", "account"})
+
+var TotalErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "crowdsec_cloudflare_worker_bouncer_errors",
+	Help: "Total number of requests that threw an exception in the worker",
+}, []string{"ip_type", "account"})
+
+var AverageLatencyMs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "crowdsec_cloudflare_worker_bouncer_avg_latency_ms",
+	Help: "Average request processing latency in milliseconds",
+}, []string{"account", "metric_name", "ip_type", "remediation"})


### PR DESCRIPTION
## Summary

Adds per-request latency tracking and worker-exception accounting on top of the Analytics Engine metrics path. Builds on #43 — the SQLi/window/dual-caller fixes are already in `main`.

**Latency capture.** The worker now measures `Date.now()` delta across the whole handler and emits it on AE `double2` alongside the existing count on `double1`. The handler body is wrapped in `try/catch/finally` so the metric still fires when `doBan`/`doCaptcha` throws — the previous multi-exit flow silently lost the event on exceptions, the same failure mode behind earlier Error 1101 incidents.

**Honest `processed` count.** Every request reaching the handler emits `processed` unconditionally; `dropped` and `error` are additional outcome tags layered on top. A blocked request emits `processed` + `dropped`; an errored request emits `processed` + `error`. `dropped / processed` stays a valid block rate and an exception no longer means an undercounted request.

**Per-series latency.** `AverageLatencyMs` is tagged with `metric_name` / `ip_type` / `remediation` so each grouped AE row gets its own series, instead of last-row-wins on a single account-scoped gauge.

**Error visibility.** New `TotalErrors` gauge, consumed by `UpdateMetrics`, so the worker's `error` event surfaces as a Prometheus metric (`crowdsec_cloudflare_worker_bouncer_errors`) rather than an "Unknown metric from AE" log warning.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/cfg/ ./pkg/cloudflare/` — new `TestUpdateMetrics_ErrorMetric`, latency assertions in `TestUpdateMetrics_HappyPath`
- [x] `golangci-lint run` — clean
- [x] `npm run build` — worker `dist/main.js` regenerated
- [ ] Confirm AE accepts `AVG(double2)` and the `double2` write path against the live SQL API
- [ ] Verify in a browser that ban/captcha paths still serve correctly and emit `processed` + `dropped`